### PR TITLE
[TNT-206] TraineeMyPage, TraineeInvitationCodeInput 화면 팝업 작성

### DIFF
--- a/TnT/Projects/Presentation/Sources/MyPage/Trainee/TraineeMyPageView.swift
+++ b/TnT/Projects/Presentation/Sources/MyPage/Trainee/TraineeMyPageView.swift
@@ -36,6 +36,9 @@ public struct TraineeMyPageView: View {
         }
         .background(Color.neutral50)
         .navigationBarBackButtonHidden()
+        .tPopUp(isPresented: $store.view_isPopUpPresented) {
+            PopUpView()
+        }
     }
     
     // MARK: - Sections
@@ -47,9 +50,9 @@ public struct TraineeMyPageView: View {
             
             Text(store.userName)
                 .typographyStyle(.heading2, with: .neutral950)
-                .padding(.bottom, store.isTrainerConnected ? 8 : 16)
+                .padding(.bottom, store.view_isTrainerConnected ? 8 : 16)
             
-            if store.isTrainerConnected {
+            if store.view_isTrainerConnected {
                 TButton(
                     title: "개인정보 수정",
                     config: .small,
@@ -64,7 +67,7 @@ public struct TraineeMyPageView: View {
     @ViewBuilder
     private func TopItemSection() -> some View {
         VStack(spacing: 12) {
-            if !store.isTrainerConnected {
+            if !store.view_isTrainerConnected {
                 ProfileItemView(title: "트레이너 연결하기", tapAction: { send(.tapConnectTrainerButton) })
                     .padding(.vertical, 4)
                     .background(Color.common0)
@@ -100,7 +103,7 @@ public struct TraineeMyPageView: View {
     @ViewBuilder
     private func BottomItemSection() -> some View {
         VStack(spacing: 12) {
-            if store.isTrainerConnected {
+            if store.view_isTrainerConnected {
                 ProfileItemView(title: "트레이너와 연결끊기", tapAction: { send(.tapDisconnectTrainerButton) })
                     .padding(.vertical, 4)
                     .background(Color.common0)
@@ -114,6 +117,30 @@ public struct TraineeMyPageView: View {
             .padding(.vertical, 12)
             .background(Color.common0)
             .clipShape(.rect(cornerRadius: 12))
+        }
+    }
+    
+    @ViewBuilder
+    private func PopUpView() -> some View {
+        if let popUp = store.view_popUp {
+            // secondaryAction nil 인 경우 제외하고 버튼 배열 구성
+            let buttons: [TPopupAlertState.ButtonState] = [
+                popUp.secondaryAction.map { action in
+                    .init(title: "취소", style: .secondary, action: .init(action: { send(action) }))
+                },
+                .init(title: "확인", style: .primary, action: .init(action: { send(popUp.primaryAction) }))
+            ].compactMap { $0 }
+            
+            TPopUpAlertView(
+                alertState: .init(
+                    title: popUp.title,
+                    message: popUp.message,
+                    showAlertIcon: popUp.showAlertIcon,
+                    buttons: buttons
+                )
+            )
+        } else {
+            EmptyView()
         }
     }
 }

--- a/TnT/Projects/Presentation/Sources/Onboarding/Trainee/TraineeInvitationCodeInput/TraineeInvitationCodeInputFeature.swift
+++ b/TnT/Projects/Presentation/Sources/Onboarding/Trainee/TraineeInvitationCodeInput/TraineeInvitationCodeInputFeature.swift
@@ -21,6 +21,8 @@ public struct TraineeInvitationCodeInputFeature {
         // MARK: Data related state
         /// 입력된 초대코드
         var invitationCode: String
+        /// 표시되는 팝업
+        var presentPopUp: PopUp?
         
         // MARK: UI related state
         /// 텍스트 필드 상태 (빈 값 / 입력됨 / 유효하지 않음)
@@ -35,25 +37,41 @@ public struct TraineeInvitationCodeInputFeature {
         var view_isNextButtonEnabled: Bool
         /// 팝업 표시 여부
         var view_isPopupPresented: Bool
+        /// 상단 네비바 표시 상태
+        var view_navigationType: NavigationType
+        
         
         /// `TraineeInvitationCodeInputFeature.State`의 생성자
         /// - Parameters:
+        ///   - invitationCode: 사용자가 입력한 초대 코드 (기본값: `""`)
+        ///   - presentPopUp: 현재 표시되는 팝업 (기본값: `nil`)
+        ///   - view_invitationCodeStatus: 텍스트 필드 상태 (`.empty`, `.valid`, `.invalid` 등)
+        ///   - view_textFieldFooterText: 텍스트 필드 하단에 표시될 메시지 (기본값: `""`)
+        ///   - view_isFieldFocused: 현재 텍스트 필드가 포커스를 받고 있는지 여부 (기본값: `false`)
+        ///   - view_isVerityButtonEnabled: "인증하기" 버튼 활성화 여부 (기본값: `false`)
+        ///   - view_isNextButtonEnabled: "다음" 버튼 활성화 여부 (기본값: `false`)
+        ///   - view_isPopupPresented: 팝업이 표시 중인지 여부 (기본값: `false`)
+        ///   - view_navigationType: 현재 화면의 네비게이션 타입 (`.newUser`: "건너뛰기" 버튼 있음, `.existingUser`: "뒤로가기" 버튼 있음)
         public init(
             invitationCode: String = "",
+            presentPopUp: PopUp? = nil,
             view_invitationCodeStatus: TTextField.Status = .empty,
             view_textFieldFooterText: String = "",
             view_isFieldFocused: Bool = false,
             view_isVerityButtonEnabled: Bool = false,
             view_isNextButtonEnabled: Bool = false,
-            view_isPopupPresented: Bool = true
+            view_isPopupPresented: Bool = false,
+            view_navigationType: NavigationType = .newUser
         ) {
             self.invitationCode = invitationCode
+            self.presentPopUp = presentPopUp
             self.view_invitationCodeStatus = view_invitationCodeStatus
             self.view_textFieldFooterText = view_textFieldFooterText
             self.view_isFieldFocused = view_isFieldFocused
             self.view_isVerityButtonEnabled = view_isVerityButtonEnabled
             self.view_isNextButtonEnabled = view_isNextButtonEnabled
             self.view_isPopupPresented = view_isPopupPresented
+            self.view_navigationType = view_navigationType
         }
     }
     
@@ -79,10 +97,16 @@ public struct TraineeInvitationCodeInputFeature {
             case setFocus(Bool)
             /// Nav바 건너뛰기 버튼이 눌렸을 때
             case tapNavBarSkipButton
+            /// Nav바 back 버튼이 눌렸을 때
+            case tapNavBarBackButton
             /// 팝업 "다음에 할게요" 버튼이 눌렸을 때
-            case tapPopupNextButton
+            case tapInvitePopupNextButton
             /// 팝업 "확인" 버튼이 눌렸을 때
-            case tapPopupConfirmButton
+            case tapInvitePopupConfirmButton
+            /// 팝업 "중단하기" 버튼이 눌렸을 때
+            case tapDropAlertStopButton
+            /// 팝업 "계속 진행" 버튼이 눌렸을 때
+            case tapDropAlertKeepButton
         }
     }
     
@@ -100,7 +124,7 @@ public struct TraineeInvitationCodeInputFeature {
                     
                 case .binding:
                     return .none
-
+                    
                 case .tapVerifyButton:
                     return .run { [state] send in
                         let result: Bool = try await traineeUseCase.verifyTrainerInvitationCode(state.invitationCode)
@@ -109,20 +133,22 @@ public struct TraineeInvitationCodeInputFeature {
                     
                 case .tapNextButton:
                     return .send(.setNavigating(.trainingInfoInput))
-                
+                    
                 case .setFocus(let isFocused):
                     state.view_isFieldFocused = isFocused
                     return .none
-                
-                case .tapNavBarSkipButton:
+                    
+                case .tapNavBarSkipButton, .tapNavBarBackButton:
+                    // 인증 후에만 팝업 표시
+                    return state.view_invitationCodeStatus == .valid
+                    ? self.setPopUpStatus(&state, status: .dropAlert)
+                    : .send(.setNavigating(.traineeHome))
+                    
+                case .tapInvitePopupNextButton, .tapDropAlertStopButton:
                     return .send(.setNavigating(.traineeHome))
                     
-                case .tapPopupNextButton:
-                    return .send(.setNavigating(.traineeHome))
-                    
-                case .tapPopupConfirmButton:
-                    state.view_isPopupPresented = false
-                    return .none
+                case .tapDropAlertKeepButton, .tapInvitePopupConfirmButton:
+                    return self.setPopUpStatus(&state, status: nil)
                 }
                 
             case .updateVerificationStatus(let isVerified):
@@ -130,7 +156,7 @@ public struct TraineeInvitationCodeInputFeature {
                 state.view_invitationCodeStatus = isVerified ? .valid : .invalid
                 state.view_isNextButtonEnabled = isVerified
                 return .none
-            
+                
             case .setNavigating:
                 return .none
             }
@@ -160,11 +186,35 @@ private extension TraineeInvitationCodeInputFeature {
         
         return .none
     }
+    
+    /// 팝업 상태, 표시 상태를 업데이트
+    func setPopUpStatus(_ state: inout State, status: PopUp?) -> Effect<Action> {
+        state.presentPopUp = status
+        state.view_isPopupPresented = status != nil
+        return .none
+    }
 }
 
 public extension TraineeInvitationCodeInputFeature {
+    /// 본 화면에서 라우팅(파생)되는 화면
     enum RoutingScreen: Sendable {
         case traineeHome
         case trainingInfoInput
+    }
+    
+    /// 본 화면에 팝업으로 표시되는 목록
+    enum PopUp: Sendable {
+        /// 진입 시 초대 코드를 입력해주세요
+        case invitePopUp
+        /// 연결을 중단하시겠어요?
+        case dropAlert
+    }
+    
+    /// 본 화면의 네비게이션 타입
+    enum NavigationType: Equatable {
+        /// 신규 유저 (우측 건너뛰기 버튼)
+        case newUser
+        /// 기존 유저 (좌측 뒤로가기 버튼)
+        case existingUser
     }
 }

--- a/TnT/Projects/Presentation/Sources/Onboarding/Trainee/TraineeInvitationCodeInput/TraineeInvitationCodeInputView.swift
+++ b/TnT/Projects/Presentation/Sources/Onboarding/Trainee/TraineeInvitationCodeInput/TraineeInvitationCodeInputView.swift
@@ -55,16 +55,7 @@ public struct TraineeInvitationCodeInputView: View {
             }
         }
         .tPopUp(isPresented: $store.view_isPopupPresented) {
-            guard let popUp = store.presentPopUp else {
-                return TPopUpAlertView(alertState: .init(title: "Error"))
-            }
-            switch popUp {
-            case .invitePopUp:
-                return TrainerInvitePopup()
-                
-            case .dropAlert:
-                return DropAlertPopup()
-            }
+            PopUpView()
         }
     }
     
@@ -130,61 +121,33 @@ public struct TraineeInvitationCodeInputView: View {
             .padding(.horizontal, 20)
         }
     }
-}
-
-private extension TraineeInvitationCodeInputView {
-    @ViewBuilder
-    /// 진입 시 트레이너 초대 코드 권유 팝업
-    private func TrainerInvitePopup() -> TPopUpAlertView {
-        TPopUpAlertView(
-            alertState: .init(
-                title: "트레이너에게 받은\n초대 코드를 입력해보세요!",
-                message: "트레이너와 연결하지 않을 경우\n일부 기능이 제한될 수 있어요.",
-                buttons: [
-                    .init(
-                        title: "다음에 할게요",
-                        style: .secondary,
-                        action: .init(action: {
-                            send(.tapInvitePopupNextButton)
-                        })
-                    ),
-                    .init(
-                        title: "확인",
-                        style: .primary,
-                        action: .init(action: {
-                            send(.tapInvitePopupConfirmButton)
-                        })
-                    )
-                ]
-            )
-        )
-    }
     
     @ViewBuilder
-    /// 코드 인증 후 화면을 벗어나려는 경우 팝업
-    private func DropAlertPopup() -> TPopUpAlertView {
-        TPopUpAlertView(
-            alertState: .init(
-                title: "트레이너 연결을 중단하시겠어요?",
-                message: "중단 시 연결을 처음부터 다시 설정해야 해요",
-                showAlertIcon: true,
-                buttons: [
-                    .init(
-                        title: "중단하기",
-                        style: .secondary,
-                        action: .init(action: {
-                            send(.tapDropAlertStopButton)
-                        })
-                    ),
-                    .init(
-                        title: "계속 진행",
-                        style: .primary,
-                        action: .init(action: {
-                            send(.tapDropAlertKeepButton)
-                        })
-                    )
-                ]
+    private func PopUpView() -> some View {
+        if let popUp = store.view_popUp {
+            let buttons: [TPopupAlertState.ButtonState] = [
+                .init(
+                    title: popUp.secondaryButtonTitle,
+                    style: .secondary,
+                    action: .init(action: { send(popUp.secondaryAction) })
+                ),
+                .init(
+                    title: popUp.primaryButtonTitle,
+                    style: .primary,
+                    action: .init(action: { send(popUp.primaryAction) })
+                )
+            ]
+            
+            TPopUpAlertView(
+                alertState: .init(
+                    title: popUp.title,
+                    message: popUp.message,
+                    showAlertIcon: popUp.showAlertIcon,
+                    buttons: buttons
+                )
             )
-        )
+        } else {
+            EmptyView()
+        }
     }
 }

--- a/TnT/Projects/Presentation/Sources/Onboarding/Trainee/TraineeInvitationCodeInput/TraineeInvitationCodeInputView.swift
+++ b/TnT/Projects/Presentation/Sources/Onboarding/Trainee/TraineeInvitationCodeInput/TraineeInvitationCodeInputView.swift
@@ -27,15 +27,7 @@ public struct TraineeInvitationCodeInputView: View {
     
     public var body: some View {
         VStack(spacing: 0) {
-            TNavigation(
-                type: .RTextWithTitle(
-                    centerTitle: "연결하기",
-                    rightText: "건너뛰기"
-                ),
-                rightAction: {
-                    send(.tapNavBarSkipButton)
-                }
-            )
+            NavigationBar()
             .padding(.bottom, 24)
             
             Header()
@@ -63,18 +55,46 @@ public struct TraineeInvitationCodeInputView: View {
             }
         }
         .tPopUp(isPresented: $store.view_isPopupPresented) {
-            PopUpView(
-                secondaryAction: {
-                    send(.tapPopupNextButton)
-                },
-                primaryAction: {
-                    send(.tapPopupConfirmButton)
+            guard let popUp = store.presentPopUp else {
+                return TPopUpAlertView(alertState: .init(title: "Error"))
+            }
+            switch popUp {
+            case .invitePopUp:
+                return TrainerInvitePopup()
+                
+            case .dropAlert:
+                return DropAlertPopup()
+            }
+        }
+    }
+    
+    // MARK: - Sections
+    @ViewBuilder
+    private func NavigationBar() -> some View {
+        switch store.view_navigationType {
+        case .newUser:
+            TNavigation(
+                type: .RTextWithTitle(
+                    centerTitle: "연결하기",
+                    rightText: "건너뛰기"
+                ),
+                rightAction: {
+                    send(.tapNavBarSkipButton)
+                }
+            )
+        case .existingUser:
+            TNavigation(
+                type: .LButtonWithTitle(
+                    leftImage: .icnArrowLeft,
+                    centerTitle: "연결하기"
+                ),
+                leftAction: {
+                    send(.tapNavBarBackButton)
                 }
             )
         }
     }
     
-    // MARK: - Sections
     @ViewBuilder
     private func Header() -> some View {
         TInfoTitleHeader(title: "트레이너에게 받은\n초대 코드를 입력해 주세요")
@@ -113,42 +133,58 @@ public struct TraineeInvitationCodeInputView: View {
 }
 
 private extension TraineeInvitationCodeInputView {
-    
-    struct PopUpView: View {
-        let secondaryAction: () -> Void
-        let primaryAction: () -> Void
-        
-        init(
-            secondaryAction: @escaping () -> Void,
-            primaryAction: @escaping () -> Void
-        ) {
-            self.secondaryAction = secondaryAction
-            self.primaryAction = primaryAction
-        }
-        
-        var body: some View {
-            TPopUpAlertView(
-                alertState: .init(
-                    title: "트레이너에게 받은\n초대 코드를 입력해보세요!",
-                    message: "트레이너와 연결하지 않을 경우\n일부 기능이 제한될 수 있어요.",
-                    buttons: [
-                        .init(
-                            title: "다음에 할게요",
-                            style: .secondary,
-                            action: .init(action: {
-                                secondaryAction()
-                            })
-                        ),
-                        .init(
-                            title: "확인",
-                            style: .primary,
-                            action: .init(action: {
-                                primaryAction()
-                            })
-                        )
-                    ]
-                )
+    @ViewBuilder
+    /// 진입 시 트레이너 초대 코드 권유 팝업
+    private func TrainerInvitePopup() -> TPopUpAlertView {
+        TPopUpAlertView(
+            alertState: .init(
+                title: "트레이너에게 받은\n초대 코드를 입력해보세요!",
+                message: "트레이너와 연결하지 않을 경우\n일부 기능이 제한될 수 있어요.",
+                buttons: [
+                    .init(
+                        title: "다음에 할게요",
+                        style: .secondary,
+                        action: .init(action: {
+                            send(.tapInvitePopupNextButton)
+                        })
+                    ),
+                    .init(
+                        title: "확인",
+                        style: .primary,
+                        action: .init(action: {
+                            send(.tapInvitePopupConfirmButton)
+                        })
+                    )
+                ]
             )
-        }
+        )
+    }
+    
+    @ViewBuilder
+    /// 코드 인증 후 화면을 벗어나려는 경우 팝업
+    private func DropAlertPopup() -> TPopUpAlertView {
+        TPopUpAlertView(
+            alertState: .init(
+                title: "트레이너 연결을 중단하시겠어요?",
+                message: "중단 시 연결을 처음부터 다시 설정해야 해요",
+                showAlertIcon: true,
+                buttons: [
+                    .init(
+                        title: "중단하기",
+                        style: .secondary,
+                        action: .init(action: {
+                            send(.tapDropAlertStopButton)
+                        })
+                    ),
+                    .init(
+                        title: "계속 진행",
+                        style: .primary,
+                        action: .init(action: {
+                            send(.tapDropAlertKeepButton)
+                        })
+                    )
+                ]
+            )
+        )
     }
 }


### PR DESCRIPTION
<!-- 제목은 {{ [TNT-00] 내용 }} 으로 작성해주세요. --> 
## 📌 What is the PR?
<!-- PR에 대한 전반적인 설명을 적어주세요. -->
- 트레이니 화면 중 네비게이션 연결에 필요한 팝업 화면을 모두 작성했습니다.
- TraineeMyPage와 TraineeInvitationCodeInput 화면의 팝업 로직을 작성했습니다.

## 🪄 Changes
<!-- 작업 내용을 리스트로 작성해주세요. -->
- TraineeMyPage PopUp 작성
- TraineeInvitationCodeInput PopUp 작성

## 🔥 PR Point
<!-- 주요 코드를 써주세요 -->
1. 기존에 작성했던 TPopUp 코드를 실 화면에서 어떻게 사용할 지 청사진을 제공합니다.
기존 PR에 작성되었던 PopUp 1개의 경우 문제가 없었으나, 화면에 표시될 PopUp이 n개인 경우 해당 데이터 값들을 모두 들고 있어야하며, 방향에 따라서는 View에서 모두 작성될수도 있다는 문제점이 발견되었습니다.
TPopUpAlertState? 타입으로 한 번에 관리하는 것이 제일 좋겠으나.. 시간과 실력 이슈로 인해 현재 구조를 가져가며 최대한 Feature 내에서 해결해보고자 노력했습니다.

- Feature에서 enum으로 PopUp 목록을 관리하며, 연산값으로 팝업 표시에 필요한 모든 내용을 반환합니다.
- 팝업의 버튼 액션은 enum 연산값으로 가져가며, case의 연관값으로 해당 enum 케이스가 들어가게 됩니다.
  - 모든 팝업의 버튼 탭 케이스를 Action에 작성하지 않고, `tapSecondaryButton(popUp)`, `tapPrimaryButton(popUp)` 두 개만으로 관리합니다. - 필요 시 switch를 활용하여 분기처리도 가능합니다
  - 이를  통해 Action from View -> Reducer의 Reduce 계산이 가능하게 됩니다

활용법은 파일을 참고하시면 됩니다.

## 📸 Screenshot
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    기능    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/afae435f-afb8-462b-92e7-224eb3c4c539" width ="250">|
| GIF | <img src = "https://github.com/user-attachments/assets/555faaa0-d2cb-42d3-bcad-88b4bd05f54e" width ="250">|
| GIF | <img src = "https://github.com/user-attachments/assets/bd0e6af0-da57-44cd-92be-0ed9f9101787" width ="250">|

## 🙆🏻 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
- 첫번째 팝업 후 두번째 팝업 시 버튼이 애니메이션 처리되며 표시되는데, 빠른 해결 방법 아신다면 부탁드림다..!

## 💭 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- #48 
