### PR TITLE
[TNT-221] 로그인/회원가입/로그아웃/회원탈퇴 간 인증 정보 처리 로직 작성

### DIFF
--- a/TnT/Projects/DIContainer/Sources/DIContainer.swift
+++ b/TnT/Projects/DIContainer/Sources/DIContainer.swift
@@ -30,8 +30,17 @@ private enum SocialUseCaseKey: DependencyKey {
     static let liveValue: SocialLoginUseCase = SocialLoginUseCase(socialLoginRepository: SocialLogInRepositoryImpl(loginManager: SNSLoginManager()))
 }
 
+private enum KeyChainManagerKey: DependencyKey {
+    static let liveValue: KeyChainManager = keyChainManager
+}
+
 // MARK: - DependencyValues
 public extension DependencyValues {
+    var keyChainManager: KeyChainManager {
+        get { self[KeyChainManagerKey.self] }
+        set { self[KeyChainManagerKey.self] = newValue }
+    }
+    
     var userUseCase: UserUseCase {
         get { self[UserUseCaseKey.self] }
         set { self[UserUseCaseKey.self] = newValue }

--- a/TnT/Projects/Data/Sources/LocalStorage/KeyChainManager.swift
+++ b/TnT/Projects/Data/Sources/LocalStorage/KeyChainManager.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 
+public let keyChainManager = KeyChainManager()
+
 /// KeyChainManager
 /// - 키체인을 통해 데이터를 CRUD 하기 위한 유틸리티입니다.
 public struct KeyChainManager {
@@ -18,7 +20,7 @@ public struct KeyChainManager {
     ///   - value: 저장할 데이터 (Generic 타입)
     ///   - key: Key 열거형으로 정의된 키
     /// - Throws: 타입 불일치, 데이터 변환 실패, 키체인 저장 실패 에러
-    public static func save<T>(_ value: T, for key: Key) throws {
+    public func save<T>(_ value: T, for key: Key) throws {
         
         guard type(of: value) == key.converter.type else {
             throw KeyChainError.typeMismatch(
@@ -50,7 +52,7 @@ public struct KeyChainManager {
     /// - Parameter key: Key 열거형으로 정의된 키
     /// - Returns: Generic 타입으로 변환된 값 (데이터가 없으면 nil)
     /// - Throws: 데이터 변환 실패, 읽기 실패, 타입 불일치 에러
-    public static func read<T>(for key: Key) throws -> T? {
+    public func read<T>(for key: Key) throws -> T? {
         let keyString: String = key.keyString
         
         let query: [String: Any] = [
@@ -89,7 +91,7 @@ public struct KeyChainManager {
     /// 키체인에서 데이터를 삭제합니다.
     /// - Parameter key: Key 열거형으로 정의된 키
     /// - Throws: 삭제 실패 에러
-    public static func delete(_ key: Key) throws {
+    public func delete(_ key: Key) throws {
         let keyString: String = key.keyString
         
         let query: [String: Any] = [
@@ -107,13 +109,13 @@ public struct KeyChainManager {
 public extension KeyChainManager {
     /// Key 열거형: 키체인에 저장할 데이터를 정의
     enum Key {
-        case token
+        case sessionId
         case userId
         
         /// 키 고유 문자열
         var keyString: String {
             switch self {
-            case .token: return "com.TnT.token"
+            case .sessionId: return "com.TnT.sessionId"
             case .userId: return "com.TnT.userId"
             }
         }
@@ -121,7 +123,7 @@ public extension KeyChainManager {
         /// 각 데이터 별 타입 & 변환 로직 정의
         var converter: KeyConverter {
             switch self {
-            case .token: return KeyConverter(type: String.self, convert: { $0 })
+            case .sessionId: return KeyConverter(type: String.self, convert: { $0 })
             case .userId: return KeyConverter(type: Int.self, convert: { Int($0) })
             }
         }

--- a/TnT/Projects/Data/Sources/Network/Interceptor/Implements/AuthToken.swift
+++ b/TnT/Projects/Data/Sources/Network/Interceptor/Implements/AuthToken.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Dependencies
 
 /// 네트워크 요청에 인증 정보를 추가하는 인터셉터
 struct AuthTokenInterceptor: Interceptor {
@@ -14,10 +15,10 @@ struct AuthTokenInterceptor: Interceptor {
 
     func adapt(request: URLRequest) async throws -> URLRequest {
         var request: URLRequest = request
-        guard let token: String = try KeyChainManager.read(for: .token) else {
+        guard let sessionId: String = try keyChainManager.read(for: .sessionId) else {
             return request
         }
-        request.setValue(token, forHTTPHeaderField: "Authorization")
+        request.setValue("SESSION-ID \(sessionId)", forHTTPHeaderField: "Authorization")
         return request
     }
 }

--- a/TnT/Projects/Data/Sources/Network/NetworkService.swift
+++ b/TnT/Projects/Data/Sources/Network/NetworkService.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 
+import Domain
+
 /// 네트워크 요청을 처리하는 서비스 클래스
 public final class NetworkService {
     
@@ -85,6 +87,9 @@ private extension NetworkService {
     
     /// JSON 데이터 디코딩
     func decodeData<T: Decodable>(_ data: Data, as type: T.Type) throws -> T {
+        // 빈 데이터인 경우 EmptyResponse 타입으로 처리
+        if data.isEmpty, let emptyValue = EmptyResponse() as? T { return emptyValue }
+        
         do {
             return try JSONDecoder(setting: .defaultSetting).decode(T.self, from: data)
         } catch let decodingError as DecodingError {

--- a/TnT/Projects/Data/Sources/Network/Service/User/UserRepositoryImpl.swift
+++ b/TnT/Projects/Data/Sources/Network/Service/User/UserRepositoryImpl.swift
@@ -40,4 +40,14 @@ public struct UserRepositoryImpl: UserRepository {
             decodingType: PostSignUpResDTO.self
         )
     }
+    
+    /// 로그아웃 요청을 수행
+    public func postLogout() async throws -> PostLogoutResDTO {
+        return try await networkService.request(UserTargetType.postLogout, decodingType: PostLogoutResDTO.self)
+    }
+    
+    /// 회원탈퇴 요청을 수행
+    public func postWithdrawal() async throws -> PostWithdrawalResDTO {
+        return try await networkService.request(UserTargetType.postWithdrawal, decodingType: PostWithdrawalResDTO.self)
+    }
 }

--- a/TnT/Projects/Data/Sources/Network/Service/User/UserRepositoryImpl.swift
+++ b/TnT/Projects/Data/Sources/Network/Service/User/UserRepositoryImpl.swift
@@ -17,6 +17,11 @@ public struct UserRepositoryImpl: UserRepository {
     
     public init() {}
     
+    /// 로그인 세션 유효 체크 요청을 수행
+    public func getSessionCheck() async throws -> GetSessionCheckResDTO {
+        return try await networkService.request(UserTargetType.getSessionCheck, decodingType: GetSessionCheckResDTO.self)
+    }
+    
     /// 소셜 로그인 요청을 수행
     public func postSocialLogin(_ reqDTO: PostSocialLoginReqDTO) async throws -> PostSocialLoginResDTO {
         return try await networkService.request(

--- a/TnT/Projects/Data/Sources/Network/Service/User/UserTargetType.swift
+++ b/TnT/Projects/Data/Sources/Network/Service/User/UserTargetType.swift
@@ -18,6 +18,10 @@ public enum UserTargetType {
     case postSocialLogin(reqDTO: PostSocialLoginReqDTO)
     /// 회원가입 요청
     case postSignUp(reqDTO: PostSignUpReqDTO, imgData: Data?)
+    /// 로그아웃 요청
+    case postLogout
+    /// 회원 탈퇴 요청
+    case postWithdrawal
 }
 
 extension UserTargetType: TargetType {
@@ -35,6 +39,12 @@ extension UserTargetType: TargetType {
             
         case .postSignUp:
             return "/members/sign-up"
+            
+        case .postLogout:
+            return "/logout"
+            
+        case .postWithdrawal:
+            return "/members/withdraw"
         }
     }
     
@@ -43,14 +53,14 @@ extension UserTargetType: TargetType {
         case .getSessionCheck:
             return .get
             
-        case .postSocialLogin, .postSignUp:
+        case .postSocialLogin, .postSignUp, .postLogout, .postWithdrawal:
             return .post
         }
     }
     
     var task: RequestTask {
         switch self {
-        case .getSessionCheck:
+        case .getSessionCheck, .postLogout, .postWithdrawal:
             return .requestPlain
         
         case .postSocialLogin(let reqDto):
@@ -70,7 +80,7 @@ extension UserTargetType: TargetType {
     
     var headers: [String: String]? {
         switch self {
-        case .getSessionCheck:
+        case .getSessionCheck, .postLogout, .postWithdrawal:
             return nil
             
         case .postSocialLogin:
@@ -86,7 +96,7 @@ extension UserTargetType: TargetType {
     
     var interceptors: [any Interceptor] {
         switch self {
-        case .getSessionCheck:
+        case .getSessionCheck, .postLogout, .postWithdrawal:
             return [
                 LoggingInterceptor(),
                 AuthTokenInterceptor(),

--- a/TnT/Projects/Data/Sources/Network/Service/User/UserTargetType.swift
+++ b/TnT/Projects/Data/Sources/Network/Service/User/UserTargetType.swift
@@ -12,6 +12,8 @@ import Domain
 
 /// 사용자 관련 API 요청 타입 정의
 public enum UserTargetType {
+    /// 로그인 세션 유효 확인
+    case getSessionCheck
     /// 소셜 로그인 요청
     case postSocialLogin(reqDTO: PostSocialLoginReqDTO)
     /// 회원가입 요청
@@ -25,6 +27,9 @@ extension UserTargetType: TargetType {
     
     var path: String {
         switch self {
+        case .getSessionCheck:
+            return "/check-session"
+            
         case .postSocialLogin:
             return "/login"
             
@@ -35,6 +40,9 @@ extension UserTargetType: TargetType {
     
     var method: HTTPMethod {
         switch self {
+        case .getSessionCheck:
+            return .get
+            
         case .postSocialLogin, .postSignUp:
             return .post
         }
@@ -42,6 +50,9 @@ extension UserTargetType: TargetType {
     
     var task: RequestTask {
         switch self {
+        case .getSessionCheck:
+            return .requestPlain
+        
         case .postSocialLogin(let reqDto):
             return .requestJSONEncodable(encodable: reqDto)
             
@@ -59,6 +70,9 @@ extension UserTargetType: TargetType {
     
     var headers: [String: String]? {
         switch self {
+        case .getSessionCheck:
+            return nil
+            
         case .postSocialLogin:
             return ["Content-Type": "application/json"]
             
@@ -71,10 +85,20 @@ extension UserTargetType: TargetType {
     }
     
     var interceptors: [any Interceptor] {
-        return [
-            LoggingInterceptor(),
-            ResponseValidatorInterceptor(),
-            RetryInterceptor(maxRetryCount: 2)
-        ]
+        switch self {
+        case .getSessionCheck:
+            return [
+                LoggingInterceptor(),
+                AuthTokenInterceptor(),
+                ResponseValidatorInterceptor(),
+                RetryInterceptor(maxRetryCount: 2)
+            ]
+        default:
+            return [
+                LoggingInterceptor(),
+                ResponseValidatorInterceptor(),
+                RetryInterceptor(maxRetryCount: 2)
+            ]
+        }
     }
 }

--- a/TnT/Projects/Domain/Sources/DTO/EmptyResponse.swift
+++ b/TnT/Projects/Domain/Sources/DTO/EmptyResponse.swift
@@ -1,0 +1,14 @@
+//
+//  EmptyResponse.swift
+//  Data
+//
+//  Created by 박민서 on 2/9/25.
+//  Copyright © 2025 yapp25thTeamTnT. All rights reserved.
+//
+
+import Foundation
+
+/// 비어 있는 응답을 처리할 빈 구조체
+public struct EmptyResponse: Decodable {
+    public init() {}
+}

--- a/TnT/Projects/Domain/Sources/DTO/User/UserResponseDTO.swift
+++ b/TnT/Projects/Domain/Sources/DTO/User/UserResponseDTO.swift
@@ -8,6 +8,11 @@
 
 import Foundation
 
+/// 로그인 세션 유효 확인 응답 DTO
+public struct GetSessionCheckResDTO: Decodable {
+    public let memberType: MemberTypeResDTO
+}
+
 /// 소셜 로그인 응답 DTO
 public struct PostSocialLoginResDTO: Decodable {
     /// 세션 ID

--- a/TnT/Projects/Domain/Sources/DTO/User/UserResponseDTO.swift
+++ b/TnT/Projects/Domain/Sources/DTO/User/UserResponseDTO.swift
@@ -61,5 +61,4 @@ public struct PostLogoutResDTO: Decodable {
 }
 
 /// 회원탈퇴 응답 DTO
-public struct PostWithdrawalResDTO: Decodable {
-}
+public typealias PostWithdrawalResDTO = EmptyResponse

--- a/TnT/Projects/Domain/Sources/DTO/User/UserResponseDTO.swift
+++ b/TnT/Projects/Domain/Sources/DTO/User/UserResponseDTO.swift
@@ -54,3 +54,12 @@ public struct PostSignUpResDTO: Decodable {
     /// 프로필 이미지 URL
     let profileImageUrl: String?
 }
+
+/// 로그아웃 응답 DTO
+public struct PostLogoutResDTO: Decodable {
+    let sessionId: String
+}
+
+/// 회원탈퇴 응답 DTO
+public struct PostWithdrawalResDTO: Decodable {
+}

--- a/TnT/Projects/Domain/Sources/Repository/UserRepository.swift
+++ b/TnT/Projects/Domain/Sources/Repository/UserRepository.swift
@@ -11,6 +11,11 @@ import Foundation
 /// 사용자 관련 데이터를 관리하는 UserRepository 프로토콜
 /// - 실제 네트워크 요청은 이 인터페이스를 구현한 `UserRepositoryImpl`에서 수행됩니다.
 public protocol UserRepository {
+    /// 로그인 세션 유효 확인
+    /// - Returns: 세션 유효 시, 멤버 타입 정보를 포함한 응답 DTO (`GetSessionCheckResDTO`)
+    /// - Throws: 네트워크 오류 또는 서버에서 반환한 오류를 발생시킬 수 있음
+    func getSessionCheck() async throws -> GetSessionCheckResDTO
+    
     /// 소셜 로그인 요청
     /// - Parameter reqDTO: 소셜 로그인 요청에 필요한 데이터 (액세스 토큰 등)
     /// - Returns: 로그인 성공 시, 사용자 정보를 포함한 응답 DTO (`PostSocialLoginResDTO`)

--- a/TnT/Projects/Domain/Sources/Repository/UserRepository.swift
+++ b/TnT/Projects/Domain/Sources/Repository/UserRepository.swift
@@ -29,4 +29,14 @@ public protocol UserRepository {
     /// - Returns: 회원가입 성공 시, 사용자 정보를 포함한 응답 DTO (`PostSignUpResDTO`)
     /// - Throws: 네트워크 오류 또는 서버에서 반환한 오류를 발생시킬 수 있음
     func postSignUp(_ reqDTO: PostSignUpReqDTO, profileImage: Data?) async throws -> PostSignUpResDTO
+    
+    /// 로그아웃 요청
+    /// - Returns: 로그아웃 완료시 SessionID 포함한 응답 DTO (`PostLogoutResDTO`)
+    /// - Throws: 네트워크 오류 또는 서버에서 반환한 오류를 발생시킬 수 있음
+    func postLogout() async throws -> PostLogoutResDTO
+    
+    /// 회원탈퇴 요청
+    /// - Returns: 회원 탈퇴 완료 시 응답 DTO (`PostWithdrawalResDTO`)
+    /// - Throws: 네트워크 오류 또는 서버에서 반환한 오류를 발생시킬 수 있음
+    func postWithdrawal() async throws -> PostWithdrawalResDTO
 }

--- a/TnT/Projects/Domain/Sources/UseCase/UserUseCase.swift
+++ b/TnT/Projects/Domain/Sources/UseCase/UserUseCase.swift
@@ -68,6 +68,10 @@ public struct DefaultUserUseCase: UserRepository, UserUseCase {
 
 // MARK: - Repository
 extension DefaultUserUseCase {
+    public func getSessionCheck() async throws -> GetSessionCheckResDTO {
+        return try await userRepostiory.getSessionCheck()
+    }
+    
     public func postSocialLogin(_ reqDTO: PostSocialLoginReqDTO) async throws -> PostSocialLoginResDTO {
         return try await userRepostiory.postSocialLogin(reqDTO)
     }
@@ -76,4 +80,3 @@ extension DefaultUserUseCase {
         return try await userRepostiory.postSignUp(reqDTO, profileImage: profileImage)
     }
 }
-

--- a/TnT/Projects/Domain/Sources/UseCase/UserUseCase.swift
+++ b/TnT/Projects/Domain/Sources/UseCase/UserUseCase.swift
@@ -79,4 +79,12 @@ extension DefaultUserUseCase {
     public func postSignUp(_ reqDTO: PostSignUpReqDTO, profileImage: Data?) async throws -> PostSignUpResDTO {
         return try await userRepostiory.postSignUp(reqDTO, profileImage: profileImage)
     }
+    
+    public func postLogout() async throws -> PostLogoutResDTO {
+        return try await userRepostiory.postLogout()
+    }
+    
+    public func postWithdrawal() async throws -> PostWithdrawalResDTO {
+        return try await userRepostiory.postWithdrawal()
+    }
 }

--- a/TnT/Projects/Presentation/Sources/Coordinator/AppFlow/AppFlowCoordinatorFeature.swift
+++ b/TnT/Projects/Presentation/Sources/Coordinator/AppFlow/AppFlowCoordinatorFeature.swift
@@ -95,10 +95,13 @@ extension AppFlowCoordinatorFeature {
         
         switch flow {
         case .onboardingFlow:
+            state.userType = nil
             state.onboardingState = .init()
         case .traineeMainFlow:
+            state.userType = .trainee
             state.traineeMainState = .init()
         case .trainerMainFlow:
+            state.userType = .trainer
             state.trainerMainState = .init()
         }
         

--- a/TnT/Projects/Presentation/Sources/Coordinator/AppFlow/AppFlowCoordinatorView.swift
+++ b/TnT/Projects/Presentation/Sources/Coordinator/AppFlow/AppFlowCoordinatorView.swift
@@ -35,6 +35,7 @@ public struct AppFlowCoordinatorView: View {
                 }
             }
         }
+        .animation(.easeInOut, value: store.userType)
         .onAppear {
             store.send(.onAppear)
         }

--- a/TnT/Projects/Presentation/Sources/Coordinator/OnboardingFlow/OnboardingFlowFeature.swift
+++ b/TnT/Projects/Presentation/Sources/Coordinator/OnboardingFlow/OnboardingFlowFeature.swift
@@ -80,11 +80,10 @@ public struct OnboardingFlowFeature {
                 case .element(id: _, action: .trainerSignUpComplete(.setNavigating)):
                     state.path.append(.trainerMakeInvitationCode(MakeInvitationCodeFeature.State()))
                     return .none
-                
-                /// 트레이너의 초대코드 화면 -> 건너뛰기 버튼 tapped
+                    
+                /// 트레이너 초대 코드 생성 화면 -> 트레이너 홈 이동
                 case .element(id: _, action: .trainerMakeInvitationCode(.setNavigation)):
-                    // 추후에 홈과 연결
-                    return .none
+                    return .send(.switchFlow(.trainerMainFlow))
                     
                 // MARK: Trainee
                 /// 트레이니 기본 정보 입력 -> PT 목적 설정 화면 이동
@@ -100,8 +99,31 @@ public struct OnboardingFlowFeature {
                 /// 트레이니 주의사항 입력 -> 트레이니 회원 가입 완료 화면 이동
                 case .element(id: _, action: .traineePrecautionInput(.setNavigating(let info))):
                     state.path.append(.traineeProfileCompletion(.init(userName: info.name, profileImage: info.profileImageUrl)))
-                        
                     return .none
+                    
+                /// 트레이니 회원가입 완료 화면 -> 트레이너 초대코드 입력 화면 이동
+                case .element(id: _, action: .traineeProfileCompletion(.setNavigating)):
+                    state.path.append(.traineeInvitationCodeInput(.init(view_popUp: .invitePopUp, view_isPopupPresented: true)))
+                    return .none
+                    
+                /// 트레이니 초대코드 입력 화면 -> 트레이니 홈화면/PT 정보 입력 화면
+                case .element(id: _, action: .traineeInvitationCodeInput(.setNavigating(let screen))):
+                    switch screen {
+                    case .traineeHome:
+                        return .send(.switchFlow(.traineeMainFlow))
+                    case .trainingInfoInput:
+                        state.path.append(.traineeTrainingInfoInput(.init()))
+                        return .none
+                    }
+                   
+                /// 트레이니 PT 정보 입력 화면 -> 연결 완료 화면
+                case .element(id: _, action: .traineeTrainingInfoInput(.setNavigating)):
+                    state.path.append(.traineeConnectionComplete(.init(userType: .trainee, traineeName: "1", trainerName: "2")))
+                    return .none
+                
+                /// 트레이니 트레이너 연결완료 -> 트레이니 홈화면
+                case .element(id: _, action: .traineeConnectionComplete(.setNavigating)):
+                    return .send(.switchFlow(.traineeMainFlow))
                     
                 default:
                     return .none

--- a/TnT/Projects/Presentation/Sources/Coordinator/OnboardingFlow/OnboardingFlowFeature.swift
+++ b/TnT/Projects/Presentation/Sources/Coordinator/OnboardingFlow/OnboardingFlowFeature.swift
@@ -153,7 +153,6 @@ extension OnboardingFlowFeature {
         
         // MARK: Trainer
         /// 트레이너 회원 가입 완료 뷰
-        /// TODO: 트레이너/트레이니 회원 가입 완료 화면으로 통합 필요
         case trainerSignUpComplete(ProfileCompletionFeature)
         /// 트레이너의 초대코드 발급 뷰
         case trainerMakeInvitationCode(MakeInvitationCodeFeature)
@@ -168,14 +167,12 @@ extension OnboardingFlowFeature {
         /// 트레이니 주의사항 입력
         case traineePrecautionInput(TraineePrecautionInputFeature)
         /// 트레이니 프로필 생성 완료
-        /// TODO: 트레이너/트레이니 회원 가입 완료 화면으로 통합 필요
         case traineeProfileCompletion(ProfileCompletionFeature)
         /// 트레이니 초대 코드입력
         case traineeInvitationCodeInput(TraineeInvitationCodeInputFeature)
         /// 트레이니 수업 정보 입력
         case traineeTrainingInfoInput(TraineeTrainingInfoInputFeature)
         /// 트레이니 연결 완료
-        /// TODO: 트레이너/트레이니 연결 완료 화면으로 통합 필요
         case traineeConnectionComplete(TraineeConnectionCompleteFeature)
     }
 }

--- a/TnT/Projects/Presentation/Sources/Coordinator/TraineeMainFlow/TraineeMainFlowFeature.swift
+++ b/TnT/Projects/Presentation/Sources/Coordinator/TraineeMainFlow/TraineeMainFlowFeature.swift
@@ -25,6 +25,8 @@ public struct TraineeMainFlowFeature {
     public enum Action: Sendable {
         /// 현재 표시되고 있는 path 화면 내부에서 일어나는 액션을 처리합니다.
         case path(StackActionOf<Path>)
+        /// Flow 변경을 AppCoordinator로 전달합니다
+        case switchFlow(AppFlow)
         case onAppear
     }
     
@@ -64,6 +66,10 @@ public struct TraineeMainFlowFeature {
                         case .traineeInvitationCodeInput:
                             state.path.append(.traineeInvitationCodeInput(.init()))
                             return .none
+                            
+                            /// 마이페이지 로그아웃/회원탈퇴 -> 온보딩 로그인 화면 이동
+                        case .onboardingLogin:
+                            return .send(.switchFlow(.onboardingFlow))
                         }
                     }
                     
@@ -85,6 +91,9 @@ public struct TraineeMainFlowFeature {
                 default:
                     return .none
                 }
+                
+            case .switchFlow:
+                return .none
                 
             case .onAppear:
                 return .none
@@ -112,7 +121,6 @@ extension TraineeMainFlowFeature {
         /// 트레이니 수업 정보 입력
         case traineeTrainingInfoInput(TraineeTrainingInfoInputFeature)
         /// 트레이니-트레이너 연결 완료
-        /// TODO: 트레이너/트레이니 연결 완료 화면으로 통합 필요
         case traineeConnectionComplete(TraineeConnectionCompleteFeature)
     }
 }

--- a/TnT/Projects/Presentation/Sources/Coordinator/TrainerMainFlow/TrainerMainFlowFeature.swift
+++ b/TnT/Projects/Presentation/Sources/Coordinator/TrainerMainFlow/TrainerMainFlowFeature.swift
@@ -64,6 +64,9 @@ public struct TrainerMainFlowFeature {
                         case .traineeInvitationCodeInput:
                             state.path.append(.traineeInvitationCodeInput(.init()))
                             return .none
+                            
+                        case .onboardingLogin:
+                            return .none
                         }
                     }
                     

--- a/TnT/Projects/Presentation/Sources/Coordinator/TrainerMainFlow/TrainerMainFlowFeature.swift
+++ b/TnT/Projects/Presentation/Sources/Coordinator/TrainerMainFlow/TrainerMainFlowFeature.swift
@@ -17,7 +17,7 @@ public struct TrainerMainFlowFeature {
     public struct State: Equatable {
         public var path: StackState<Path.State>
         
-        public init(path: StackState<Path.State> = .init([])) {
+        public init(path: StackState<Path.State> = .init([.mainTab(.home(.init()))])) {
             self.path = path
         }
     }

--- a/TnT/Projects/Presentation/Sources/Onboarding/CreateProfile/CreateProfileFeature.swift
+++ b/TnT/Projects/Presentation/Sources/Onboarding/CreateProfile/CreateProfileFeature.swift
@@ -92,6 +92,7 @@ public struct CreateProfileFeature {
     
     @Dependency(\.userUseCase) private var userUseCase: UserUseCase
     @Dependency(\.userUseRepoCase) private var userUseRepoCase: UserRepository
+    @Dependency(\.keyChainManager) var keyChainManager
     
     public enum Action: Sendable, ViewAction {
         /// 네비게이션 여부 설정
@@ -160,7 +161,7 @@ public struct CreateProfileFeature {
                 
                 return .run { send in
                     let result = try await userUseRepoCase.postSignUp(reqDTO, profileImage: imgData).toEntity()
-                    // TODO: 세션, 유저타입 정보 키체인 저장
+                    saveSessionId(result.sessionId)
                     await send(.setNavigating(.trainerSignUpComplete(result)))
                 }
                 
@@ -188,6 +189,16 @@ private extension CreateProfileFeature {
         state.view_textFieldStatus = .filled
         state.view_isNextButtonEnabled = true
         return .none
+    }
+    
+    /// 세션 값 저장
+    private func saveSessionId(_ sessionId: String?) {
+        guard let sessionId else { return }
+        do {
+            try keyChainManager.save(sessionId, for: .sessionId)
+        } catch {
+            print("로그인 정보 저장 싪패")
+        }
     }
 }
 

--- a/TnT/Projects/Presentation/Sources/Onboarding/Trainee/TraineePrecautionInput/TraineePrecautionInputFeature.swift
+++ b/TnT/Projects/Presentation/Sources/Onboarding/Trainee/TraineePrecautionInput/TraineePrecautionInputFeature.swift
@@ -62,6 +62,7 @@ public struct TraineePrecautionInputFeature {
     
     @Dependency(\.userUseCase) private var userUseCase: UserUseCase
     @Dependency(\.userUseRepoCase) private var userUseRepoCase: UserRepository
+    @Dependency(\.keyChainManager) var keyChainManager
     
     public enum Action: Sendable, ViewAction {
         /// 뷰에서 발생한 액션을 처리합니다.
@@ -114,7 +115,7 @@ public struct TraineePrecautionInputFeature {
                 
                 return .run { send in
                     let result = try await userUseRepoCase.postSignUp(reqDTO, profileImage: imgData).toEntity()
-                    // TODO: 세션, 유저타입 정보 키체인 저장
+                    saveSessionId(result.sessionId)
                     await send(.setNavigating(result))
                 }
                 
@@ -137,5 +138,15 @@ private extension TraineePrecautionInputFeature {
         state.view_editorStatus = .filled
         state.view_isNextButtonEnabled = true
         return .none
+    }
+    
+    /// 세션 값 저장
+    private func saveSessionId(_ sessionId: String?) {
+        guard let sessionId else { return }
+        do {
+            try keyChainManager.save(sessionId, for: .sessionId)
+        } catch {
+            print("로그인 정보 저장 싪패")
+        }
     }
 }

--- a/TnT/Projects/Presentation/Sources/Onboarding/Trainee/TraineeProfileCompletion/ProfileCompletionView.swift
+++ b/TnT/Projects/Presentation/Sources/Onboarding/Trainee/TraineeProfileCompletion/ProfileCompletionView.swift
@@ -64,37 +64,29 @@ public struct ProfileCompletionView: View {
                 .multilineTextAlignment(.center)
         }
     }
-
-    @ViewBuilder
-    private func ImageSection() -> some View {
-        Image(.imgDefaultTraineeImage)
-            .resizable()
-            .frame(width: 200, height: 200)
-            .clipShape(Circle())
-    }
     
     @ViewBuilder
-    public func ImageSection(imgURL: URL) -> some View {
+    public func ImageSection() -> some View {
         if let urlString = store.profileImage, let url = URL(string: urlString) {
             AsyncImage(url: url) { phase in
                 switch phase {
                 case .empty:
                     ProgressView()
                         .tint(.red500)
-                        .frame(width: 132, height: 132)
+                        .frame(width: 200, height: 200)
                     
                 case .success(let image):
                     image
                         .resizable()
                         .aspectRatio(contentMode: .fill)
-                        .frame(width: 132, height: 132)
+                        .frame(width: 200, height: 200)
                         .clipShape(Circle())
                     
                 case .failure:
                     Image(store.userType == .trainee ? .imgDefaultTraineeImage : .imgDefaultTrainerImage)
                         .resizable()
                         .aspectRatio(contentMode: .fill)
-                        .frame(width: 132, height: 132)
+                        .frame(width: 200, height: 200)
                         .clipShape(Circle())
                     
                 @unknown default:
@@ -105,7 +97,7 @@ public struct ProfileCompletionView: View {
             Image(store.userType == .trainee ? .imgDefaultTraineeImage : .imgDefaultTrainerImage)
                 .resizable()
                 .scaledToFill()
-                .frame(width: 132, height: 132)
+                .frame(width: 200, height: 200)
                 .clipShape(Circle())
         }
     }


### PR DESCRIPTION
<!-- 제목은 {{ [TNT-00] 내용 }} 으로 작성해주세요. --> 
## 📌 What is the PR?
<!-- PR에 대한 전반적인 설명을 적어주세요. -->
- 앱 흐름에서 인증 정보가 처리되는 부분을 API 로직, 키체인과 연결하여 작성했습니다.

## 🪄 Changes
<!-- 작업 내용을 리스트로 작성해주세요. -->
- 키체인에 SessionId 추가 로직 작성
- 앱 진입 시 세션 체크 로직 작성
- 로그인, 회원 가입 시 세션 저장 로직 작성
- 로그아웃, 회원 탈퇴 시 세션 삭제 로직 작성
- 세션 정보에 따른 앱 코디네이트 관리 로직 작성

## 🌐 Common Changes
<!-- 공통 작업 부분에 대한 수정 사항이 있다면 적어주세요 -->
- KeyChainManager가 static에서 기본 함수로 변경, DIContainer에 등록하여 사용합니다
- API 콜 중 Response가 비어서 오는 응답의 경우 EmptyResponse를 사용하여 받습니다  

## 🔥 PR Point
<!-- 주요 코드를 써주세요 -->
1. 앱 진입 시, AppFlowCoordinatorFeature에서 checkSessionInfo를 통해 KeyChain에 등록되어있는 세션 정보를 확인합니다.
존재하는 경우 API를 통해 유효한지 검증하며, 유효하지 않거나 존재하지 않는 경우 온보딩 화면으로 이동합니다.
유효한 경우, 각 유저 타입에 맞는 화면으로 라우팅됩니다.
```swift
case .api(let action):
                switch action {
                case .checkSession:
                    return .run { send in
                        let result = try? await userUseCaseRepo.getSessionCheck()
                        switch result?.memberType {
                        case .trainer:
                            await send(.updateUserInfo(.trainer))
                        case .trainee:
                            await send(.updateUserInfo(.trainee))
                        default:
                            try keyChainManager.delete(.sessionId)
                            await send(.updateUserInfo(nil))
                        }
                    }
                }
            
            case .checkSessionInfo:
                let session: String? = try? keyChainManager.read(for: .sessionId)
                return session != nil
                ? .send(.api(.checkSession))
                : .send(.updateUserInfo(nil))
                
            case .updateUserInfo(let userType):
                switch userType {
                case .trainee:
                    return self.setFlow(.traineeMainFlow, state: &state)
                case .trainer:
                    return self.setFlow(.trainerMainFlow, state: &state)
                default:
                    return self.setFlow(.onboardingFlow, state: &state)
                }
```

2. 마이페이지에서 로그아웃/회원탈퇴 시 API 호출 후 KeyChain 삭제 - 온보딩 화면으로 라우팅 흐름으로 진행됩니다.
회원 탈퇴 시 API response body가 비어서 오기 때문에 EmptyResponse를 typealias로 바꿔 넣어주었고, 키체인 삭제 후 화면 전환은 코디네이터를 통해 진행했습니다.


## 🙆🏻 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
- 추후 리팩토링 시에 DTO를 모두 Data단에 옮기게 될 텐데, 이때 EmptyResponse도 꼭 같이 옮겨야할 것 같습니다.
- 나머지는 #62 머지 후에 작업이 가능하여 - TrainerUseRepoCase가 필요 - 여기까지 작업후 PR 올립니다!

## 💭 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- #61 
