### PR TITLE
[TNT-227] 트레이니 식단 등록 화면 API 연결

### DIFF
--- a/TnT/Projects/Data/Sources/Network/Service/Trainee/TraineeRepositoryImpl.swift
+++ b/TnT/Projects/Data/Sources/Network/Service/Trainee/TraineeRepositoryImpl.swift
@@ -23,4 +23,8 @@ public struct TraineeRepositoryImpl: TraineeRepository {
             decodingType: PostConnectTrainerResDTO.self
         )
     }
+    
+    public func postTraineeDietRecord(_ reqDTO: PostTraineeDietRecordReqDTO, imgData: Data?) async throws -> PostTraineeDietRecordResDTO {
+        return try await networkService.request(TraineeTargetType.postTraineeDietRecord(reqDto: reqDTO, imgData: imgData), decodingType: PostTraineeDietRecordResDTO.self)
+    }
 }

--- a/TnT/Projects/Domain/Sources/DTO/Trainee/TraineeRequestDTO.swift
+++ b/TnT/Projects/Domain/Sources/DTO/Trainee/TraineeRequestDTO.swift
@@ -31,3 +31,23 @@ public struct PostConnectTrainerReqDTO: Encodable {
         self.finishedPtCount = finishedPtCount
     }
 }
+
+/// 트레이니 식단 기록 요청 DTO
+public struct PostTraineeDietRecordReqDTO: Encodable {
+    /// 식단 dateTime
+    public let date: String
+    /// 식단 타입
+    public let dietType: String
+    /// 식단 메모
+    public let memo: String
+    
+    public init(
+        date: String,
+        dietType: String,
+        memo: String
+    ) {
+        self.date = date
+        self.dietType = dietType
+        self.memo = memo
+    }
+}

--- a/TnT/Projects/Domain/Sources/DTO/Trainee/TraineeResponseDTO.swift
+++ b/TnT/Projects/Domain/Sources/DTO/Trainee/TraineeResponseDTO.swift
@@ -19,3 +19,6 @@ public struct PostConnectTrainerResDTO: Decodable {
     /// 트레이니 프로필 이미지 URL
     public let traineeProfileImageUrl: String
 }
+
+/// 트레이니 식단 기록 응답 DTO
+public typealias PostTraineeDietRecordResDTO = EmptyResponse

--- a/TnT/Projects/Domain/Sources/Entity/DietType.swift
+++ b/TnT/Projects/Domain/Sources/Entity/DietType.swift
@@ -9,8 +9,8 @@
 import Foundation
 
 /// 앱에서 존재하는 식단 유형을 정의한 열거형
-public enum DietType: Sendable, CaseIterable {
-    case morning
+public enum DietType: String, Sendable, CaseIterable {
+    case breakfast
     case lunch
     case dinner
     case snack
@@ -18,7 +18,7 @@ public enum DietType: Sendable, CaseIterable {
     /// 식사 유형을 한글로 변환하여 반환
     public var koreanName: String {
         switch self {
-        case .morning: return "아침"
+        case .breakfast: return "아침"
         case .lunch: return "점심"
         case .dinner: return "저녁"
         case .snack: return "간식"

--- a/TnT/Projects/Domain/Sources/Policy/TDateFormat.swift
+++ b/TnT/Projects/Domain/Sources/Policy/TDateFormat.swift
@@ -34,4 +34,6 @@ public enum TDateFormat: String {
     case a_HHmm = "a HH:mm"
     /// "17:00"
     case HHmm = "HH:mm"
+    /// "2024-02-12T15:30:00Z"
+    case ISO8601 = "yyyy-MM-dd'T'HH:mm:ss'Z'"
 }

--- a/TnT/Projects/Domain/Sources/Repository/TraineeRepository.swift
+++ b/TnT/Projects/Domain/Sources/Repository/TraineeRepository.swift
@@ -16,4 +16,12 @@ public protocol TraineeRepository {
     /// - Returns: 연결 성공 시, 연결된 트레이너 정보가 포함된 응답 DTO (`PostConnectTrainerResDTO`)
     /// - Throws: 네트워크 오류 또는 잘못된 요청 데이터로 인한 서버 오류 발생 가능
     func postConnectTrainer(_ reqDTO: PostConnectTrainerReqDTO) async throws -> PostConnectTrainerResDTO
+    
+    /// 회원가입 요청
+    /// - Parameters:
+    ///   - reqDTO: 식단 등록 요청에 필요한 데이터
+    ///   - imgData: 사용자가 업로드한 식단 이미지 (옵션)
+    /// - Returns: 등록 성공 시, 응답 DTO (empty) (`PostTraineeDietRecordResDTO`)
+    /// - Throws: 네트워크 오류 또는 서버에서 반환한 오류를 발생시킬 수 있음
+    func postTraineeDietRecord(_ reqDTO: PostTraineeDietRecordReqDTO, imgData: Data?) async throws -> PostTraineeDietRecordResDTO
 }

--- a/TnT/Projects/Domain/Sources/UseCase/TraineeUseCase.swift
+++ b/TnT/Projects/Domain/Sources/UseCase/TraineeUseCase.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2025 yapp25thTeamTnT. All rights reserved.
 //
 
+import Foundation
+
 // MARK: - TraineeUseCase 프로토콜
 public protocol TraineeUseCase {
     /// 입력 초대 코드 검증
@@ -65,5 +67,9 @@ public struct DefaultTraineeUseCase: TraineeUseCase {
 extension DefaultTraineeUseCase: TraineeRepository {
     public func postConnectTrainer(_ reqDTO: PostConnectTrainerReqDTO) async throws -> PostConnectTrainerResDTO {
         return try await traineeRepository.postConnectTrainer(reqDTO)
+    }
+    
+    public func postTraineeDietRecord(_ reqDTO: PostTraineeDietRecordReqDTO, imgData: Data?) async throws -> PostTraineeDietRecordResDTO {
+        return try await traineeRepository.postTraineeDietRecord(reqDTO, imgData: imgData)
     }
 }

--- a/TnT/Projects/Presentation/Sources/AddDietRecord/TraineeAddDietRecordView.swift
+++ b/TnT/Projects/Presentation/Sources/AddDietRecord/TraineeAddDietRecordView.swift
@@ -254,20 +254,24 @@ public struct TraineeAddDietRecordView: View {
     
     @ViewBuilder
     private func DietInfoSection() -> some View {
-        TTextEditor(
-            placeholder: "식단에 대한 정보를 입력해주세요!",
-            text: $store.dietInfo,
-            textEditorStatus: $store.view_dietInfoStatus,
-            footer: {
-                .init(
-                    textLimit: 100,
-                    status: $store.view_dietInfoStatus,
-                    textCount: store.dietInfo.count,
-                    warningText: "100자 미만으로 입력해주세요"
-                )
-            }
-        )
-        .focused($focusedField, equals: .dietInfo)
+        VStack(alignment: .leading, spacing: 8) {
+            TTextField.Header(isRequired: true, title: "메모하기", limitCount: nil, textCount: nil)
+            
+            TTextEditor(
+                placeholder: "식단에 대한 정보를 입력해주세요!",
+                text: $store.dietInfo,
+                textEditorStatus: $store.view_dietInfoStatus,
+                footer: {
+                    .init(
+                        textLimit: 100,
+                        status: $store.view_dietInfoStatus,
+                        textCount: store.dietInfo.count,
+                        warningText: "100자 미만으로 입력해주세요"
+                    )
+                }
+            )
+            .focused($focusedField, equals: .dietInfo)
+        }
     }
     
     @ViewBuilder

--- a/TnT/Projects/Presentation/Sources/Coordinator/TraineeMainFlow/TraineeMainFlowFeature.swift
+++ b/TnT/Projects/Presentation/Sources/Coordinator/TraineeMainFlow/TraineeMainFlowFeature.swift
@@ -84,6 +84,11 @@ public struct TraineeMainFlowFeature {
                     // 특정 화면 append
                     return .none
                     
+                    /// 식단 기록 화면 등록 -> 홈화면으로 이동
+                case .element(id: _, action: .addDietRecordPage(.setNavigating)):
+                    state.path.removeLast()
+                    return .none
+                    
                     /// 마이페이지 초대코드 입력화면 다음 버튼 탭 - > PT 정보 입력 화면 or 홈 이동
                 case .element(_, action: .traineeInvitationCodeInput(.setNavigating(let screen))):
                     switch screen {

--- a/TnT/Projects/Presentation/Sources/PresentationSupport/DietType.swift
+++ b/TnT/Projects/Presentation/Sources/PresentationSupport/DietType.swift
@@ -13,7 +13,7 @@ extension DietType {
     /// 해당 식단을 표시하는 이모지 입니다
     var emoji: String {
         switch self {
-        case .morning:
+        case .breakfast:
             "🌞"
         case .lunch:
             "⛅"


### PR DESCRIPTION
<!-- 제목은 {{ [TNT-00] 내용 }} 으로 작성해주세요. --> 
## 📌 What is the PR?
<!-- PR에 대한 전반적인 설명을 적어주세요. -->
- 트레이니 식단 기록 화면의 API를 연결하고, 등록 완료 후 화면 흐름을 연결했습니다

## 🪄 Changes
<!-- 작업 내용을 리스트로 작성해주세요. -->
- postTraineeDietRecord 작성
- 화면 API 연결

## 🌐 Common Changes
<!-- 공통 작업 부분에 대한 수정 사항이 있다면 적어주세요 -->
- DietType의 아침에 해당하는 `morning`이 `breakfast`로 리네이밍 되었습니다

## 📸 Screenshot
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    기능    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/5d2415bb-8dc2-4533-b422-6ee6d01f9ee9" width ="250">|

## 🙆🏻 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
- 트레이니 식단 등록 화면 완입니다!

## 💭 Related Issues
<!-- 작업한 이슈번호를 # 뒤 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- #73
