### PR TITLE
[TNT-195] 트레이니 홈, 식단 확인 화면 API 연결

### DIFF
--- a/TnT/Projects/Data/Sources/Network/Service/Trainee/TraineeRepositoryImpl.swift
+++ b/TnT/Projects/Data/Sources/Network/Service/Trainee/TraineeRepositoryImpl.swift
@@ -27,4 +27,16 @@ public struct TraineeRepositoryImpl: TraineeRepository {
     public func postTraineeDietRecord(_ reqDTO: PostTraineeDietRecordReqDTO, imgData: Data?) async throws -> PostTraineeDietRecordResDTO {
         return try await networkService.request(TraineeTargetType.postTraineeDietRecord(reqDto: reqDTO, imgData: imgData), decodingType: PostTraineeDietRecordResDTO.self)
     }
+    
+    public func getActiveDateList(startDate: String, endDate: String) async throws -> GetActiveDateListResDTO {
+        return try await networkService.request(TraineeTargetType.getActiveDateList(startDate: startDate, endDate: endDate), decodingType: GetActiveDateListResDTO.self)
+    }
+    
+    public func getActiveDateDetail(date: String) async throws -> GetActiveDateDetailResDTO {
+        return try await networkService.request(TraineeTargetType.getActiveDateDetail(date: date), decodingType: GetActiveDateDetailResDTO.self)
+    }
+    
+    public func getDietRecordDetail(dietId: Int) async throws -> GetDietRecordDetailResDTO {
+        return try await networkService.request(TraineeTargetType.getDietRecordDetail(dietId: dietId), decodingType: GetDietRecordDetailResDTO.self)
+    }
 }

--- a/TnT/Projects/DesignSystem/Sources/Components/Calendar/TCalendarRepresentable.swift
+++ b/TnT/Projects/DesignSystem/Sources/Components/Calendar/TCalendarRepresentable.swift
@@ -64,7 +64,6 @@ public struct TCalendarRepresentable: UIViewRepresentable {
         calendar.appearance.titleDefaultColor = .clear
         calendar.calendarWeekdayView.weekdayLabels[0].textColor = UIColor(.red500)
         
-        
         return calendar
     }
 

--- a/TnT/Projects/DesignSystem/Sources/Components/Calendar/TCalendarView.swift
+++ b/TnT/Projects/DesignSystem/Sources/Components/Calendar/TCalendarView.swift
@@ -43,7 +43,11 @@ public struct TCalendarView: View {
         GeometryReader { proxy in
             TCalendarRepresentable(
                 selectedDate: $selectedDate,
-                currentPage: $currentPage,
+                currentPage: Binding(get: {
+                    currentPage
+                }, set: {
+                    if $0 != currentPage { currentPage = $0 }
+                }),
                 calendarHeight: $calendarHeight,
                 mode: mode,
                 events: events

--- a/TnT/Projects/DesignSystem/Sources/Components/Card/TRecordCard.swift
+++ b/TnT/Projects/DesignSystem/Sources/Components/Card/TRecordCard.swift
@@ -10,7 +10,7 @@ import SwiftUI
 
 /// 트레이니 - 운동/식단 카드
 public struct TRecordCard: View {
-    private let chipUIInfo: TChip.UIInfo
+    private let chipUIInfo: TChip.UIInfo?
     private let timeText: String
     private let title: String
     private let imgURL: URL?
@@ -18,7 +18,7 @@ public struct TRecordCard: View {
     private let footerTapAction: (() -> Void)?
     
     public init(
-        chipUIInfo: TChip.UIInfo,
+        chipUIInfo: TChip.UIInfo?,
         timeText: String,
         title: String,
         imgURL: URL?,
@@ -94,7 +94,9 @@ public struct TRecordCard: View {
     @ViewBuilder
     public func Header() -> some View {
         HStack {
-            TChip(uiInfo: chipUIInfo)
+            if let chipUIInfo {
+                TChip(uiInfo: chipUIInfo)
+            }
             Spacer()
             TimeIndicator(timeText: timeText)
         }

--- a/TnT/Projects/Domain/Sources/DTO/Trainee/TraineeResponseDTO.swift
+++ b/TnT/Projects/Domain/Sources/DTO/Trainee/TraineeResponseDTO.swift
@@ -22,3 +22,59 @@ public struct PostConnectTrainerResDTO: Decodable {
 
 /// 트레이니 식단 기록 응답 DTO
 public typealias PostTraineeDietRecordResDTO = EmptyResponse
+
+/// 트레이니 캘린더 수업/기록 존재 날짜 조회 응답 DTO
+public struct GetActiveDateListResDTO: Decodable {
+    public let ptLessonDates: [String]
+}
+
+/// 특정 날짜 수업/기록 조회 응답 DTO
+public struct GetActiveDateDetailResDTO: Decodable {
+    public let date: String
+    public let ptInfo: PTInfoResDTO?
+    public let diets: [DietResDTO]
+}
+
+/// PT 정보에 사용되는 PTInfoResDTO
+public struct PTInfoResDTO: Decodable {
+    /// 트레이너 이름
+    public let trainerName: String
+    /// 세션 회차
+    public let session: Int
+    /// 수업 시작 시간
+    public let lessonStart: String
+    /// 수업 종료 시간
+    public let lessonEnd: String
+}
+
+/// 식단 정보에 사용되는 DietResDTO
+public struct DietResDTO: Decodable {
+    /// 식단 ID
+    public let dietId: Int
+    /// 식단 시간
+    public let date: String
+    /// 식단 이미지 URL
+    public let dietImageUrl: String?
+    /// 식단 타입
+    public let dietType: DietTypeResDTO
+    /// 식단 메모
+    public let memo: String
+}
+
+/// Breakfast, lunch, dinner, snack으로 구분되는 DietTypeResDTO
+public enum DietTypeResDTO: String, Decodable {
+    case breakfast = "BREAKFAST"
+    case lunch = "LUNCH"
+    case dinner = "DINNER"
+    case snack = "SNACK"
+    case unknown = ""
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        self = DietTypeResDTO(rawValue: rawValue) ?? .unknown
+    }
+}
+
+/// 특정 식단 조회 응답 DTO
+public typealias GetDietRecordDetailResDTO = DietResDTO

--- a/TnT/Projects/Domain/Sources/DTO/Trainee/TraineeResponseDTO.swift
+++ b/TnT/Projects/Domain/Sources/DTO/Trainee/TraineeResponseDTO.swift
@@ -33,18 +33,42 @@ public struct GetActiveDateDetailResDTO: Decodable {
     public let date: String
     public let ptInfo: PTInfoResDTO?
     public let diets: [DietResDTO]
+    
+    enum CodingKeys: String, CodingKey {
+        case date, ptInfo, diets
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        date = try container.decode(String.self, forKey: .date)
+        diets = try container.decode([DietResDTO].self, forKey: .diets)
+        
+        let ptInfoDecoded = try container.decodeIfPresent(PTInfoResDTO.self, forKey: .ptInfo)
+        ptInfo = ptInfoDecoded?.isEmpty == true ? nil : ptInfoDecoded
+    }
 }
 
 /// PT 정보에 사용되는 PTInfoResDTO
 public struct PTInfoResDTO: Decodable {
     /// 트레이너 이름
-    public let trainerName: String
+    public let trainerName: String?
+    /// 트레이니 이미지 URL
+    public let trainerProfileImage: String?
     /// 세션 회차
-    public let session: Int
+    public let session: Int?
     /// 수업 시작 시간
-    public let lessonStart: String
+    public let lessonStart: String?
     /// 수업 종료 시간
-    public let lessonEnd: String
+    public let lessonEnd: String?
+    
+    /// 모든 프로퍼티가 nil인지 확인하는 computed property
+    public var isEmpty: Bool {
+        return trainerName == nil &&
+        trainerProfileImage == nil &&
+        session == nil &&
+        lessonStart == nil &&
+        lessonEnd == nil
+    }
 }
 
 /// 식단 정보에 사용되는 DietResDTO

--- a/TnT/Projects/Domain/Sources/Entity/DietType.swift
+++ b/TnT/Projects/Domain/Sources/Entity/DietType.swift
@@ -24,4 +24,9 @@ public enum DietType: String, Sendable, CaseIterable {
         case .snack: return "간식"
         }
     }
+    
+    public init?(from recordType: RecordType) {
+        guard case .diet(let type) = recordType else { return nil }
+        self = type
+    }
 }

--- a/TnT/Projects/Domain/Sources/Entity/RecordListItemEntity.swift
+++ b/TnT/Projects/Domain/Sources/Entity/RecordListItemEntity.swift
@@ -9,13 +9,13 @@
 import Foundation
 
 /// 트레이니 기록 목록 아이템 모델
-public struct RecordListItemEntity: Equatable {
+public struct RecordListItemEntity: Equatable, Sendable {
     /// 기록 id
     public let id: Int
     /// 기록 타입
-    public let type: RecordType
+    public let type: RecordType?
     /// 기록 시간
-    public let date: Date
+    public let date: Date?
     /// 기록 제목
     public let title: String
     /// 피드백 여부
@@ -25,8 +25,8 @@ public struct RecordListItemEntity: Equatable {
     
     public init(
         id: Int,
-        type: RecordType,
-        date: Date,
+        type: RecordType?,
+        date: Date?,
         title: String,
         hasFeedBack: Bool,
         imageUrl: String?

--- a/TnT/Projects/Domain/Sources/Entity/WorkoutListItemEntity.swift
+++ b/TnT/Projects/Domain/Sources/Entity/WorkoutListItemEntity.swift
@@ -9,15 +9,15 @@
 import Foundation
 
 /// 트레이니 PT 운동 목록 아이템 모델
-public struct WorkoutListItemEntity: Equatable {
+public struct WorkoutListItemEntity: Equatable, Sendable {
     /// 수업 Id
     public let id: Int
     /// 현재 수업 차수
     public let currentCount: Int
     /// 수업 시작 시간
-    public let startDate: Date
+    public let startDate: Date?
     /// 수업 종료 시간
-    public let endDate: Date
+    public let endDate: Date?
     /// 트레이너 프로필 사진 URL
     public let trainerProfileImageUrl: String?
     /// 트레이너 이름
@@ -28,8 +28,8 @@ public struct WorkoutListItemEntity: Equatable {
     public init(
         id: Int,
         currentCount: Int,
-        startDate: Date,
-        endDate: Date,
+        startDate: Date?,
+        endDate: Date?,
         trainerProfileImageUrl: String?,
         trainerName: String,
         hasRecord: Bool

--- a/TnT/Projects/Domain/Sources/Mapper/TraineeMapper.swift
+++ b/TnT/Projects/Domain/Sources/Mapper/TraineeMapper.swift
@@ -1,0 +1,59 @@
+//
+//  TraineeMapper.swift
+//  Domain
+//
+//  Created by 박민서 on 2/14/25.
+//  Copyright © 2025 yapp25thTeamTnT. All rights reserved.
+//
+
+import Foundation
+
+public extension PTInfoResDTO {
+    func toEntity() -> WorkoutListItemEntity? {
+        guard !self.isEmpty else { return nil }
+        return .init(
+            id: Int.random(in: 1...10000),
+            currentCount: self.session ?? 0,
+            startDate: self.lessonStart?.toDate(format: .ISO8601),
+            endDate: self.lessonEnd?.toDate(format: .ISO8601),
+            trainerProfileImageUrl: self.trainerProfileImage,
+            trainerName: self.trainerName ?? "",
+            hasRecord: false
+        )
+    }
+}
+
+public extension DietResDTO {
+    func toEntity() -> RecordListItemEntity {
+        return .init(
+            id: self.dietId,
+            type: self.dietType.toEntity(),
+            date: self.date.toDate(format: .ISO8601),
+            title: self.memo,
+            hasFeedBack: false,
+            imageUrl: self.dietImageUrl
+        )
+    }
+}
+
+public extension DietTypeResDTO {
+    func toEntity() -> RecordType? {
+        let dietType: DietType? = {
+            switch self {
+            case .breakfast:
+                return .breakfast
+            case .lunch:
+                return .lunch
+            case .dinner:
+                return .dinner
+            case .snack:
+                return .snack
+            case .unknown:
+                return nil
+            }
+        }()
+        
+        guard let dietType else { return nil }
+        return .diet(type: dietType)
+    }
+}

--- a/TnT/Projects/Domain/Sources/Repository/TraineeRepository.swift
+++ b/TnT/Projects/Domain/Sources/Repository/TraineeRepository.swift
@@ -24,4 +24,26 @@ public protocol TraineeRepository {
     /// - Returns: 등록 성공 시, 응답 DTO (empty) (`PostTraineeDietRecordResDTO`)
     /// - Throws: 네트워크 오류 또는 서버에서 반환한 오류를 발생시킬 수 있음
     func postTraineeDietRecord(_ reqDTO: PostTraineeDietRecordReqDTO, imgData: Data?) async throws -> PostTraineeDietRecordResDTO
+    
+    /// 캘린더 수업, 기록 존재하는 날짜 조회 요청
+    /// - Parameters:
+    ///   - startDate: 조회 시작 날짜
+    ///   - endDate: 조회 종료 날짜
+    /// - Returns: 등록 성공 시, 응답 DTO (`GetActiveDateListResDTO`)
+    /// - Throws: 네트워크 오류 또는 서버에서 반환한 오류를 발생시킬 수 있음
+    func getActiveDateList(startDate: String, endDate: String) async throws -> GetActiveDateListResDTO
+    
+    /// 특정 날짜 수업, 기록 조회
+    /// - Parameters:
+    ///   - date: 조회 특정 날짜
+    /// - Returns: 등록 성공 시, 응답 DTO (`GetActiveDateDetailResDTO`)
+    /// - Throws: 네트워크 오류 또는 서버에서 반환한 오류를 발생시킬 수 있음
+    func getActiveDateDetail(date: String) async throws -> GetActiveDateDetailResDTO
+    
+    /// 특정 식단 조회 요청
+    /// - Parameters:
+    ///   - dietId: 조회 특정 식단 ID
+    /// - Returns: 등록 성공 시, 응답 DTO (`GetDietRecordDetailResDTO`)
+    /// - Throws: 네트워크 오류 또는 서버에서 반환한 오류를 발생시킬 수 있음
+    func getDietRecordDetail(dietId: Int) async throws -> GetDietRecordDetailResDTO
 }

--- a/TnT/Projects/Domain/Sources/UseCase/TraineeUseCase.swift
+++ b/TnT/Projects/Domain/Sources/UseCase/TraineeUseCase.swift
@@ -72,4 +72,16 @@ extension DefaultTraineeUseCase: TraineeRepository {
     public func postTraineeDietRecord(_ reqDTO: PostTraineeDietRecordReqDTO, imgData: Data?) async throws -> PostTraineeDietRecordResDTO {
         return try await traineeRepository.postTraineeDietRecord(reqDTO, imgData: imgData)
     }
+    
+    public func getActiveDateList(startDate: String, endDate: String) async throws -> GetActiveDateListResDTO {
+        return try await traineeRepository.getActiveDateList(startDate: startDate, endDate: endDate)
+    }
+    
+    public func getActiveDateDetail(date: String) async throws -> GetActiveDateDetailResDTO {
+        return try await traineeRepository.getActiveDateDetail(date: date)
+    }
+    
+    public func getDietRecordDetail(dietId: Int) async throws -> GetDietRecordDetailResDTO {
+        return try await traineeRepository.getDietRecordDetail(dietId: dietId)
+    }
 }

--- a/TnT/Projects/Presentation/Sources/Coordinator/TraineeMainFlow/TraineeMainFlowFeature.swift
+++ b/TnT/Projects/Presentation/Sources/Coordinator/TraineeMainFlow/TraineeMainFlowFeature.swift
@@ -61,6 +61,9 @@ public struct TraineeMainFlowFeature {
                         case .traineeInvitationCodeInput:
                             state.path.append(.traineeInvitationCodeInput(.init(view_navigationType: .existingUser)))
                             return .none
+                        case .dietDetailPage(let id):
+                            state.path.append(.dietRecordDetail(.init(dietId: id)))
+                            return .none
                         }
                         /// 트레이니 마이페이지
                     case .traineeMyPage(let screen):
@@ -147,6 +150,8 @@ extension TraineeMainFlowFeature {
         case alarmCheck(AlarmCheckFeature)
         /// 식단 기록 추가
         case addDietRecordPage(TraineeAddDietRecordFeature)
+        /// 식단 상세 화면
+        case dietRecordDetail(TraineeDietRecordDetailFeature)
         
         // MARK: MyPage
         /// 트레이니 초대 코드입력

--- a/TnT/Projects/Presentation/Sources/Coordinator/TraineeMainFlow/TraineeMainFlowView.swift
+++ b/TnT/Projects/Presentation/Sources/Coordinator/TraineeMainFlow/TraineeMainFlowView.swift
@@ -32,6 +32,8 @@ public struct TraineeMainFlowView: View {
                 AlarmCheckView(store: store)
             case .addDietRecordPage(let store):
                 TraineeAddDietRecordView(store: store)
+            case .dietRecordDetail(let store):
+                TraineeDietRecordDetailView(store: store)
                 
                 // MARK: MyPage
             case .traineeInvitationCodeInput(let store):

--- a/TnT/Projects/Presentation/Sources/DietRecordDetail/TraineeDietRecordDetailView.swift
+++ b/TnT/Projects/Presentation/Sources/DietRecordDetail/TraineeDietRecordDetailView.swift
@@ -52,6 +52,9 @@ public struct TraineeDietRecordDetailView: View {
         }
         .navigationBarBackButtonHidden()
         .keyboardDismissOnTap()
+        .onAppear {
+            send(.onAppear)
+        }
     }
     
     // MARK: - Sections
@@ -90,7 +93,7 @@ public struct TraineeDietRecordDetailView: View {
     
     @ViewBuilder
     private func ContentSection() -> some View {
-        VStack(spacing: 8) {
+        VStack(alignment: .leading, spacing: 8) {
             VStack(alignment: .leading, spacing: 0) {
                 if let chipInfo = store.dietType?.chipInfo {
                     TChip(uiInfo: chipInfo)

--- a/TnT/Projects/Presentation/Sources/Home/Trainee/TraineeHomeFeature.swift
+++ b/TnT/Projects/Presentation/Sources/Home/Trainee/TraineeHomeFeature.swift
@@ -103,6 +103,8 @@ public struct TraineeHomeFeature {
             case tapShowSessionRecordButton(id: Int)
             /// 기록 목록 피드백 보기 버튼 탭
             case tapShowRecordFeedbackButton(id: Int)
+            /// 기록 아이템 탭
+            case tapRecordItem(type: RecordType?, id: Int)
             /// 우측 하단 기록 추가 버튼 탭
             case tapAddRecordButton
             /// 개인 운동 기록 추가 버튼 탭
@@ -159,6 +161,14 @@ public struct TraineeHomeFeature {
                     // TODO: 네비게이션 연결 시 추가
                     print("tapShowRecordFeedbackButton \(id)")
                     return .none
+                    
+                case let .tapRecordItem(recordType, id):
+                    switch recordType {
+                    case .diet:
+                        return .send(.setNavigating(.dietDetailPage(id: id)))
+                    default:
+                        return .none
+                    }
                     
                 case .tapAddRecordButton:
                     state.view_isBottomSheetPresented = true
@@ -280,13 +290,15 @@ extension TraineeHomeFeature {
 }
 
 extension TraineeHomeFeature {
-    public enum RoutingScreen: Sendable {
+    public enum RoutingScreen: Equatable, Sendable {
         /// 알림 페이지
         case alarmPage
         /// 수업 기록 상세 페이지
         case sessionRecordPage
         /// 기록 피드백 페이지
         case recordFeedbackPage
+        /// 식단 상세 페이지
+        case dietDetailPage(id: Int)
         /// 운동 기록 추가 페이지
         case addWorkoutRecordPage
         /// 식단 기록 추가 페이지

--- a/TnT/Projects/Presentation/Sources/Home/Trainee/TraineeHomeFeature.swift
+++ b/TnT/Projects/Presentation/Sources/Home/Trainee/TraineeHomeFeature.swift
@@ -208,7 +208,8 @@ public struct TraineeHomeFeature {
                 case .onAppear:
                     return .concatenate(
                         .send(.showPopUp),
-                        currentPageUpdated(state: &state)
+                        currentPageUpdated(state: &state),
+                        .send(.api(.getActiveDateDetail(date: state.selectedDate)))
                     )
                 }
                 

--- a/TnT/Projects/Presentation/Sources/Home/Trainee/TraineeHomeView.swift
+++ b/TnT/Projects/Presentation/Sources/Home/Trainee/TraineeHomeView.swift
@@ -152,6 +152,9 @@ public struct TraineeHomeView: View {
                                 send(.tapShowRecordFeedbackButton(id: item.id))
                             }
                         )
+                        .onTapGesture {
+                            send(.tapRecordItem(type: item.type, id: item.id))
+                        }
                     }
                 } else {
                     RecordEmptyView()

--- a/TnT/Projects/Presentation/Sources/Home/Trainee/TraineeHomeView.swift
+++ b/TnT/Projects/Presentation/Sources/Home/Trainee/TraineeHomeView.swift
@@ -60,7 +60,7 @@ public struct TraineeHomeView: View {
         .navigationBarBackButtonHidden()
         .sheet(isPresented: $store.view_isBottomSheetPresented) {
             TraineeRecordStartView(itemContents: [
-                ("🏋🏻‍♀️", "개인 운동", { send(.tapAddWorkoutRecordButton) }),
+//                ("🏋🏻‍♀️", "개인 운동", { send(.tapAddWorkoutRecordButton) }),
                 ("🥗", "식단", { send(.tapAddDietRecordButton) })
             ])
             .padding(.top, 10)

--- a/TnT/Projects/Presentation/Sources/Home/Trainee/TraineeHomeView.swift
+++ b/TnT/Projects/Presentation/Sources/Home/Trainee/TraineeHomeView.swift
@@ -143,8 +143,8 @@ public struct TraineeHomeView: View {
                 if !store.records.isEmpty {
                     ForEach(store.records, id: \.id) { item in
                         TRecordCard(
-                            chipUIInfo: item.type.chipInfo,
-                            timeText: TDateFormatUtility.formatter(for: .a_HHmm).string(from: item.date),
+                            chipUIInfo: item.type?.chipInfo,
+                            timeText: item.date?.toString(format: .a_HHmm) ?? "",
                             title: item.title,
                             imgURL: URL(string: item.imageUrl ?? ""),
                             hasFeedback: item.hasFeedBack,


### PR DESCRIPTION
<!-- 제목은 {{ [TNT-00] 내용 }} 으로 작성해주세요. --> 
## 📌 What is the PR?
<!-- PR에 대한 전반적인 설명을 적어주세요. -->
- 트레이니 홈 화면과 식단 확인 화면의 API, 연결 흐름을 작성했습니다.

## 🪄 Changes
<!-- 작업 내용을 리스트로 작성해주세요. -->
- Trainee 관련 API 최신화
- 트레이니 홈 화면 API 작성
- 트레이니 식단 확인 화면 API 작성

## 🌐 Common Changes
<!-- 공통 작업 부분에 대한 수정 사항이 있다면 적어주세요 -->
- TCalendarView 내부의 selectedDate 바인딩 변수에 변경되었을 때만 setter 호출하도록 수정했습니다.

## 🔥 PR Point
<!-- 주요 코드를 써주세요 -->
- 홈화면의 캘린더 관련 데이터 로드에서 단순 캐싱 로직을 사용했습니다.
1. 한달 +- 1주를 엑스트라로 한번에 받고, 이를 배열에 한달치로 저장합니다.
2. 이때 해당 달을 로드된 달 Set에 추가하며, 이후로 API를 호출할 때 해당 집합에 존재하는 경우 API를 호출하지 않아 불필요한 API 콜을 막습니다.

## 📸 Screenshot
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    기능    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/user-attachments/assets/8b9139b6-f3b3-48fb-888e-f5e37d98af29" width ="250">|

## 🙆🏻 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
- API 완!

## 💭 Related Issues
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 이슈가 닫히는 것을 원치 않는 경우 `Resolved:`를 지워주세요 -->
- Resolved: #85 
