### PR TITLE
[TNT-254] 앱 FCM  알람 딥링크 동작 구현

### DIFF
--- a/TnT/Projects/Data/Sources/Network/Service/Trainer/TrainerRepositoryImpl.swift
+++ b/TnT/Projects/Data/Sources/Network/Service/Trainer/TrainerRepositoryImpl.swift
@@ -50,7 +50,7 @@ public struct TrainerRepositoryImpl: TrainerRepository {
         return try await networkService.request(TrainerTargetType.getMonthlyLessonList(year: year, month: month), decodingType: GetMonthlyLessonListResDTO.self)
     }
     
-    public func getConnectedTraineeInfo(trainerId: Int, traineeId: Int) async throws -> GetConnectedTraineeInfoResponseDTO {
+    public func getConnectedTraineeInfo(trainerId: Int64, traineeId: Int64) async throws -> GetConnectedTraineeInfoResponseDTO {
         return try await networkService.request(TrainerTargetType.getConnectedTraineeInfo(trainerId: trainerId, traineeId: traineeId), decodingType: GetConnectedTraineeInfoResponseDTO.self)
     }
     

--- a/TnT/Projects/Data/Sources/Network/Service/Trainer/TrainerTargetType.swift
+++ b/TnT/Projects/Data/Sources/Network/Service/Trainer/TrainerTargetType.swift
@@ -25,7 +25,7 @@ public enum TrainerTargetType {
     /// 회원 조희
     case getMemebersList
     /// 연결 완료된 트레이니 최초로 정보 불러오기
-    case getConnectedTraineeInfo(trainerId: Int, traineeId: Int)
+    case getConnectedTraineeInfo(trainerId: Int64, traineeId: Int64)
     /// 관리 중인 회원 목록 요청
     case getActiveTraineesList
     /// PT 수업 추가

--- a/TnT/Projects/Domain/Sources/DTO/Trainer/GetConnectedTraineeInfoResponseDTO.swift
+++ b/TnT/Projects/Domain/Sources/DTO/Trainer/GetConnectedTraineeInfoResponseDTO.swift
@@ -31,11 +31,11 @@ public struct ConnectTraineeInfoDTO: Decodable {
     /// 나이
     let age: Int?
     /// 키
-    let height: Double
+    let height: Double?
     /// 몸무게
-    let weight: Double
+    let weight: Double?
     /// PT 목표
-    let ptGoal: String
+    let ptGoal: String?
     /// 주의 사항
     let cautionNote: String?
 }

--- a/TnT/Projects/Domain/Sources/Extension/Notification+.swift
+++ b/TnT/Projects/Domain/Sources/Extension/Notification+.swift
@@ -19,6 +19,8 @@ public extension Notification.Name {
     static let hideProgressNotification = Notification.Name("HideProgressNotification")
     /// 세션 만료 팝업을 표시하기 위한 노티피케이션 이름
     static let showSessionExpiredPopupNotification = Notification.Name("ShowSessionExpiredPopupNotification")
+    /// FCM 토큰 - 트레이너/트레이니 연결 완료 receive 노티피케이션 이름
+    static let fcmUserConnectedNotification = Notification.Name("FCMUserConnectedNotification")
 }
 
 public extension NotificationCenter {

--- a/TnT/Projects/Domain/Sources/Mapper/TrainerMapper.swift
+++ b/TnT/Projects/Domain/Sources/Mapper/TrainerMapper.swift
@@ -18,7 +18,7 @@ public extension ConnectTraineeInfoDTO {
             age: self.age,
             height: height,
             weight: weight,
-            ptGoal: self.ptGoal,
+            ptGoal: self.ptGoal ?? "",
             cautionNote: self.cautionNote
         )
     }

--- a/TnT/Projects/Domain/Sources/Repository/TrainerRepository.swift
+++ b/TnT/Projects/Domain/Sources/Repository/TrainerRepository.swift
@@ -30,7 +30,7 @@ public protocol TrainerRepository {
     func getMonthlyLessonList(year: Int, month: Int) async throws -> GetMonthlyLessonListResDTO
     
     /// 연결 완료된 트레이니 정보 불러오기
-    func getConnectedTraineeInfo(trainerId: Int, traineeId: Int) async throws -> GetConnectedTraineeInfoResponseDTO
+    func getConnectedTraineeInfo(trainerId: Int64, traineeId: Int64) async throws -> GetConnectedTraineeInfoResponseDTO
     
     /// 관리 중인 회원 목록 요청
     func getActiveTraineesList() async throws -> GetActiveTraineesListResDTO

--- a/TnT/Projects/Domain/Sources/UseCase/TrainerUseCase.swift
+++ b/TnT/Projects/Domain/Sources/UseCase/TrainerUseCase.swift
@@ -33,7 +33,7 @@ public struct DefaultTrainerUseCase: TrainerRepository {
         return try await trainerRepository.getDateSessionList(date: date)
     }
     
-    public func getConnectedTraineeInfo(trainerId: Int, traineeId: Int) async throws -> GetConnectedTraineeInfoResponseDTO {
+    public func getConnectedTraineeInfo(trainerId: Int64, traineeId: Int64) async throws -> GetConnectedTraineeInfoResponseDTO {
         return try await trainerRepository.getConnectedTraineeInfo(trainerId: trainerId, traineeId: traineeId)
     }
     

--- a/TnT/Projects/Presentation/Sources/Coordinator/AppFlow/AppFlowCoordinatorView.swift
+++ b/TnT/Projects/Presentation/Sources/Coordinator/AppFlow/AppFlowCoordinatorView.swift
@@ -69,5 +69,30 @@ public struct AppFlowCoordinatorView: View {
                 )
             )
         }
+        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name.showSessionExpiredPopupNotification)) { notification in
+            send(.notification(.showSessionExpiredPopup))
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name.fcmUserConnectedNotification)) { notification in
+            guard let userInfo = notification.userInfo else { return }
+            let trainerId: Int64 = {
+                if let value = userInfo["trainerId"] as? Int64 {
+                    return value
+                } else if let string = userInfo["trainerId"] as? String,
+                          let value = Int64(string) {
+                    return value
+                }
+                return 0
+            }()
+            let traineeId: Int64 = {
+                if let value = userInfo["traineeId"] as? Int64 {
+                    return value
+                } else if let string = userInfo["traineeId"] as? String,
+                          let value = Int64(string) {
+                    return value
+                }
+                return 0
+            }()
+            send(.notification(.showConnectCompletion(trainerId: trainerId, traineeId: traineeId)))
+        }
     }
 }

--- a/TnT/Projects/Presentation/Sources/Coordinator/OnboardingFlow/OnboardingFlowFeature.swift
+++ b/TnT/Projects/Presentation/Sources/Coordinator/OnboardingFlow/OnboardingFlowFeature.swift
@@ -14,7 +14,7 @@ import Domain
 @Reducer
 public struct OnboardingFlowFeature {
     @ObservableState
-    public struct State: Equatable {
+    public struct State: Equatable, Sendable {
         public var path: StackState<Path.State>
         @Shared var signUpEntity: PostSignUpEntity
         
@@ -47,9 +47,9 @@ public struct OnboardingFlowFeature {
                 case .element(id: _, action: .snsLogin(.setNavigating(let screen))):
                     switch screen {
                     case .traineeHome:
-                        return .send(.switchFlow(.traineeMainFlow))
+                        return .send(.switchFlow(.traineeMainFlow(.init())))
                     case .trainerHome:
-                        return .send(.switchFlow(.trainerMainFlow))
+                        return .send(.switchFlow(.trainerMainFlow(.init())))
                     case .userTypeSelection:
                         state.path.append(.userTypeSelection(.init(signUpEntity: state.$signUpEntity)))
                     }
@@ -83,7 +83,7 @@ public struct OnboardingFlowFeature {
                     
                 /// 트레이너 초대 코드 생성 화면 -> 트레이너 홈 이동
                 case .element(id: _, action: .trainerMakeInvitationCode(.setNavigation)):
-                    return .send(.switchFlow(.trainerMainFlow))
+                    return .send(.switchFlow(.trainerMainFlow(.init())))
                     
                 // MARK: Trainee
                 /// 트레이니 기본 정보 입력 -> PT 목적 설정 화면 이동
@@ -110,7 +110,7 @@ public struct OnboardingFlowFeature {
                 case .element(id: _, action: .traineeInvitationCodeInput(.setNavigating(let screen))):
                     switch screen {
                     case .traineeHome:
-                        return .send(.switchFlow(.traineeMainFlow))
+                        return .send(.switchFlow(.traineeMainFlow(.init())))
                     case let .trainingInfoInput(trainerName, invitationCode):
                         state.path.append(.traineeTrainingInfoInput(.init(trainerName: trainerName, invitationCode: invitationCode)))
                         return .none
@@ -133,7 +133,7 @@ public struct OnboardingFlowFeature {
                 
                 /// 트레이니 트레이너 연결완료 -> 트레이니 홈화면
                 case .element(id: _, action: .traineeConnectionComplete(.setNavigating)):
-                    return .send(.switchFlow(.traineeMainFlow))
+                    return .send(.switchFlow(.traineeMainFlow(.init())))
                     
                 default:
                     return .none

--- a/TnT/Projects/Presentation/Sources/Coordinator/TraineeMainFlow/TraineeMainFlowFeature.swift
+++ b/TnT/Projects/Presentation/Sources/Coordinator/TraineeMainFlow/TraineeMainFlowFeature.swift
@@ -78,7 +78,7 @@ public struct TraineeMainFlowFeature {
                             
                             /// 마이페이지 로그아웃/회원탈퇴 -> 온보딩 로그인 화면 이동
                         case .onboardingLogin:
-                            return .send(.switchFlow(.onboardingFlow))
+                            return .send(.switchFlow(.onboardingFlow(.init())))
                         }
                     }
                     

--- a/TnT/Projects/Presentation/Sources/Coordinator/TrainerMainFlow/TrainerMainFlowFeature.swift
+++ b/TnT/Projects/Presentation/Sources/Coordinator/TrainerMainFlow/TrainerMainFlowFeature.swift
@@ -14,7 +14,7 @@ import Domain
 @Reducer
 public struct TrainerMainFlowFeature {
     @ObservableState
-    public struct State: Equatable {
+    public struct State: Equatable, Sendable {
         public var path: StackState<Path.State>
         
         public init(path: StackState<Path.State> = .init([.mainTab(.home(.init()))])) {
@@ -69,7 +69,7 @@ public struct TrainerMainFlowFeature {
                     case .trainerMyPage(let screen):
                         switch screen {
                         case .onboardingLogin:
-                            return .send(.switchFlow(.onboardingFlow))
+                            return .send(.switchFlow(.onboardingFlow(.init())))
                         }
                     }
                     

--- a/TnT/Projects/Presentation/Sources/Onboarding/Trainer/Login/Connection/ConnectedTraineeProfileView.swift
+++ b/TnT/Projects/Presentation/Sources/Onboarding/Trainer/Login/Connection/ConnectedTraineeProfileView.swift
@@ -25,32 +25,30 @@ public struct ConnectedTraineeProfileView: View {
     }
     
     public var body: some View {
-        NavigationStack {
-            ZStack {
-                Image(.imgConnectionCompleteBackground)
-                    .resizable()
-                    .scaledToFill()
-                    .frame(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height)
-                    .clipped()
-                    .ignoresSafeArea()
+        ZStack {
+            Image(.imgConnectionCompleteBackground)
+                .resizable()
+                .scaledToFill()
+                .frame(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.height)
+                .clipped()
+                .ignoresSafeArea()
+            
+            VStack(spacing: 0) {
+                Spacer()
                 
-                VStack(spacing: 0) {
-                    Spacer()
-                    
-                    traineeView()
-                   
-                    Spacer()
-                    
-                    TBottomButton(title: "시작하기", isEnable: true) {
-                        send(.startButtonTapped)
-                    }
-                    .padding(.bottom, .safeAreaBottom)
-                    .ignoresSafeArea(.all, edges: .bottom)
+                traineeView()
+               
+                Spacer()
+                
+                TBottomButton(title: "시작하기", isEnable: true) {
+                    send(.startButtonTapped)
                 }
+                .padding(.bottom, .safeAreaBottom)
+                .ignoresSafeArea(.all, edges: .bottom)
             }
-            .navigationBarBackButtonHidden()
         }
         .background(Color.neutral800)
+        .navigationBarBackButtonHidden()
     }
     
     @ViewBuilder

--- a/TnT/Projects/Presentation/Sources/Onboarding/Trainer/Login/Connection/ConnectionCompleteFeature.swift
+++ b/TnT/Projects/Presentation/Sources/Onboarding/Trainer/Login/Connection/ConnectionCompleteFeature.swift
@@ -15,14 +15,14 @@ import Domain
 public struct ConnectionCompleteFeature {
     @ObservableState
     public struct State: Equatable {
-        var traineeId: Int?
-        var trainerId: Int?
+        var traineeId: Int64?
+        var trainerId: Int64?
         var connectionInfo: ConnectionInfoEntity?
         var traineeProfile: ConnectedTraineeProfileEntity?
         
         public init(
-            traineeId: Int? = nil,
-            trainerId: Int? = nil,
+            traineeId: Int64? = nil,
+            trainerId: Int64? = nil,
             connectionInfo: ConnectionInfoEntity? = nil,
             traineeProfile: ConnectedTraineeProfileEntity? = nil
         ) {

--- a/TnT/Projects/Presentation/Sources/Onboarding/Trainer/Login/Connection/ConnectionCompleteView.swift
+++ b/TnT/Projects/Presentation/Sources/Onboarding/Trainer/Login/Connection/ConnectionCompleteView.swift
@@ -53,6 +53,7 @@ public struct ConnectionCompleteView: View {
                 .ignoresSafeArea(.all, edges: .bottom)
             }
         }
+        .onAppear { send(.onAppear) }
         .navigationBarBackButtonHidden()
     }
     

--- a/TnT/Projects/TnTApp/Sources/Application/AppDelegate.swift
+++ b/TnT/Projects/TnTApp/Sources/Application/AppDelegate.swift
@@ -12,6 +12,7 @@ import FirebaseMessaging
 import UserNotifications
 
 import Data
+import Domain
 
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
@@ -60,6 +61,31 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     ) {
         completionHandler([.sound, .badge, .list, .banner])
     }
+    
+    /// fore/background 알림 탭했을 때 처리
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        let userInfo = response.notification.request.content.userInfo
+        
+        if let trainerIdString = userInfo["trainerId"] as? String,
+           let trainerId = Int64(trainerIdString),
+           let traineeIdString = userInfo["traineeId"] as? String,
+           let traineeId = Int64(traineeIdString) {
+            NotificationCenter.default.post(
+                name: NSNotification.Name.fcmUserConnectedNotification,
+                object: nil,
+                userInfo: [
+                    "trainerId": trainerId,
+                    "traineeId": traineeId
+                ]
+            )
+        }
+        
+        completionHandler()
+    }
 }
 
 // MARK: - MessagingDelegate (FCM 토큰 가져오기)
@@ -77,5 +103,14 @@ extension AppDelegate: MessagingDelegate {
         }
 
         print("✅ FCM 등록 토큰: \(fcmToken)")
+    }
+}
+
+extension AppDelegate {
+    // SceneDelegate
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        let sceneConfig = UISceneConfiguration(name: nil, sessionRole: connectingSceneSession.role)
+        sceneConfig.delegateClass = SceneDelegate.self
+        return sceneConfig
     }
 }

--- a/TnT/Projects/TnTApp/Sources/Application/SceneDelegate.swift
+++ b/TnT/Projects/TnTApp/Sources/Application/SceneDelegate.swift
@@ -7,13 +7,32 @@
 //
 
 import UIKit
+import Domain
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        guard (scene is UIWindowScene) else { return }
+        if let notificationResponse = connectionOptions.notificationResponse {
+            let userInfo = notificationResponse.notification.request.content.userInfo
+
+            if let trainerIdString = userInfo["trainerId"] as? String,
+               let trainerId = Int64(trainerIdString),
+               let traineeIdString = userInfo["traineeId"] as? String,
+               let traineeId = Int64(traineeIdString) {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+                    NotificationCenter.default.post(
+                        name: NSNotification.Name.fcmUserConnectedNotification,
+                        object: nil,
+                        userInfo: [
+                            "trainerId": trainerId,
+                            "traineeId": traineeId
+                        ]
+                    )
+                }
+            }
+        }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {


### PR DESCRIPTION
<!-- 제목은 {{ [TNT-00] 내용 }} 으로 작성해주세요. --> 
## 📌 What is the PR?
<!-- PR에 대한 전반적인 설명을 적어주세요. -->
- 포어그라운드/백그라운드/종료 시의 앱의 모든 시점에서 알람을 받아 동작하도록 구현했습니다.
- 트레이너-트레이니 연결 알림을 받으면 해당 연결 정보 화면으로 바로 이동하는 딥링크 기능을 추가했습니다.

## 🪄 Changes
<!-- 작업 내용을 리스트로 작성해주세요. -->
1. FCM 메시지 수신 및 파싱
- Firebase Messaging 문서를 기반으로 Delegate 코드를 구현했습니다.
- 푸시 알림 페이로드에서 딥링크 데이터를 추출하여 딥링크 타입에 따라 Routing Action을 생성했습니다.

2. AppCoordinator 딥링크 처리
- DeeplinkAction enum을 추가했습니다.
  - `openTrainerConnection`: 트레이너 연결 화면으로 이동
  - `openSchedule`: 일정 상세 화면으로 이동
- 딥링크 Action을 기존 Navigator Action으로 변환하여 처리합니다.

3. 앱 생명주기별 딥링크 처리
- 앱 종료 상태: 푸시 알림 탭 → 앱 실행 → 딥링크 처리
- 백그라운드 상태: 푸시 알림 탭 → 앱 활성화 → 딥링크 처리
- 포어그라운드 상태: 알림 배너 탭 → 딥링크 처리

## 🙆🏻 To Reviewers
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
- 나중에 구조 깔끔하게 다듬어서 다시..

