### PR TITLE
[TNT-310] 트레이너 화면 UI 변동 사항 반영

### DIFF
--- a/TnT/Projects/DesignSystem/Resources/Assets.xcassets/Icons/icn_check_mark_light_green.imageset/Contents.json
+++ b/TnT/Projects/DesignSystem/Resources/Assets.xcassets/Icons/icn_check_mark_light_green.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "icn_check_mark_light_green.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TnT/Projects/DesignSystem/Resources/Assets.xcassets/Icons/icn_check_mark_light_green.imageset/icn_check_mark_light_green.svg
+++ b/TnT/Projects/DesignSystem/Resources/Assets.xcassets/Icons/icn_check_mark_light_green.imageset/icn_check_mark_light_green.svg
@@ -1,0 +1,4 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="40" cy="40" r="29" fill="#D9FFE6"/>
+<path d="M30 39.9333L36.0455 46L49 33" stroke="#1ED45A" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/TnT/Projects/DesignSystem/Resources/Assets.xcassets/Icons/icn_question_mark.imageset/Contents.json
+++ b/TnT/Projects/DesignSystem/Resources/Assets.xcassets/Icons/icn_question_mark.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "icn_question_mark.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/TnT/Projects/DesignSystem/Resources/Assets.xcassets/Icons/icn_question_mark.imageset/icn_question_mark.svg
+++ b/TnT/Projects/DesignSystem/Resources/Assets.xcassets/Icons/icn_question_mark.imageset/icn_question_mark.svg
@@ -1,0 +1,5 @@
+<svg width="80" height="80" viewBox="0 0 80 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="40" cy="40" r="29" fill="#FFF0F0"/>
+<rect x="37" y="49" width="6" height="6" rx="3" fill="#FF5D58"/>
+<path d="M34.5 34.5C34.5 32 36.15 29 40 29C43.85 29 45.5 31.5 45.5 34.5C45.5 39 40 40 40 40V44.5" stroke="#FF5D58" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/TnT/Projects/DesignSystem/Sources/Components/PopUp/TPopUpAlertState.swift
+++ b/TnT/Projects/DesignSystem/Sources/Components/PopUp/TPopUpAlertState.swift
@@ -17,6 +17,8 @@ public struct TPopupAlertState: Equatable {
     public var message: String?
     /// 팝업의 경고 아이콘 표시 (옵션)
     public var showAlertIcon: Bool
+    /// 팝업에 표시할 커스텀 아이콘 (옵션)
+    public var icon: PopupIcon?
     /// 팝업에 표시될 버튼 배열
     public var buttons: [ButtonState]
     
@@ -25,17 +27,39 @@ public struct TPopupAlertState: Equatable {
     ///   - title: 팝업의 제목
     ///   - message: 팝업의 메시지 (선택 사항, 기본값: `nil`)
     ///   - showAlertIcon: 팝업의 경고 아이콘 표시 (기본값: `false`)
+    ///   - icon: 팝업에 표시할 커스텀 아이콘 (기본값: `nil`)
     ///   - buttons: 팝업에 표시할 버튼 배열 (기본값: 빈 배열)
     public init(
         title: String,
         message: String? = nil,
         showAlertIcon: Bool = false,
+        icon: PopupIcon? = nil,
         buttons: [ButtonState] = []
     ) {
         self.title = title
         self.message = message
         self.showAlertIcon = showAlertIcon
+        self.icon = icon
         self.buttons = buttons
+    }
+}
+
+public extension TPopupAlertState {
+    enum PopupIcon {
+        case warning
+        case checkMarkLightGreen
+        case questionMark
+        
+        var imageResource: ImageResource {
+            switch self {
+            case .warning:
+                return .icnWarning
+            case .checkMarkLightGreen:
+                return .icnCheckMarkLightGreen
+            case .questionMark:
+                return .icnQuestionMark
+            }
+        }
     }
 }
 

--- a/TnT/Projects/DesignSystem/Sources/Components/PopUp/TPopUpAlertView.swift
+++ b/TnT/Projects/DesignSystem/Sources/Components/PopUp/TPopUpAlertView.swift
@@ -24,13 +24,14 @@ public struct TPopUpAlertView: View {
             // 텍스트 Section
             VStack(spacing: 8) {
                 VStack(spacing: 0) {
-                    if alertState.showAlertIcon {
+                    if let icon = alertState.icon {
+                        Image(icon.imageResource)
+                        .resizable()
+                        .frame(width: 80, height: 80)
+                    } else if alertState.showAlertIcon {
                         Image(.icnWarning)
                             .resizable()
                             .frame(width: 80, height: 80)
-                    } else {
-                        Color.clear
-                            .frame(height: 20)
                     }
                     Text(alertState.title)
                         .typographyStyle(.heading3, with: .neutral900)

--- a/TnT/Projects/DesignSystem/Sources/Components/TextField/TBoxTextEditor.swift
+++ b/TnT/Projects/DesignSystem/Sources/Components/TextField/TBoxTextEditor.swift
@@ -1,0 +1,195 @@
+//
+//  TBoxTextEditor.swift
+//  DesignSystem
+//
+//  Created by Codex on 11/22/25.
+//  Copyright © 2025 yapp25thTeamTnT. All rights reserved.
+//
+
+import SwiftUI
+
+/// 박스형 테두리를 사용하는 커스텀 텍스트 에디터입니다.
+/// 기존 TTextEditor와 동일한 인터페이스로 상태/푸터를 지원합니다.
+public struct TBoxTextEditor: View {
+
+    /// TextEditor 수평 패딩 값
+    private static let horizontalPadding: CGFloat = 16
+    /// TextEditor 수직 패딩 값
+    private static let verticalPadding: CGFloat = 12
+    /// TextEditor 기본 높이값
+    public static let defaultHeight: CGFloat = 40
+
+    /// 하단에 표시되는 푸터 뷰
+    private let footer: Footer?
+    /// Placeholder 텍스트
+    private let placeholder: String
+    /// 텍스트 에디터 사이즈
+    private let size: Size
+    /// 텍스트 필드 상태
+    @Binding private var status: Status
+    /// 입력된 텍스트
+    @Binding private var text: String
+
+    /// 내부에서 동적으로 관리되는 텍스트 에디터 높이
+    @State private var textHeight: CGFloat = defaultHeight
+    /// 텍스트 에디터 포커스 상태
+    @FocusState var isFocused: Bool
+
+    /// TBoxTextEditor 생성자
+    /// - Parameters:
+    ///   - placeholder: Placeholder 텍스트 (기본값: "내용을 입력해주세요").
+    ///   - size: 텍스트 에디터 사이즈.
+    ///   - text: 입력된 텍스트를 관리하는 바인딩.
+    ///   - textEditorStatus: 텍스트 에디터 상태를 관리하는 바인딩.
+    ///   - footer: TextEditor 하단에 표시될 `TBoxTextEditor.Footer`를 정의하는 클로저.
+    public init(
+        placeholder: String = "내용을 입력해주세요",
+        size: Size = .large,
+        text: Binding<String>,
+        textEditorStatus: Binding<Status>,
+        footer: () -> Footer? = { nil }
+    ) {
+        self.placeholder = placeholder
+        self.size = size
+        self._text = text
+        self._status = textEditorStatus
+        self.footer = footer()
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ZStack(alignment: .topLeading) {
+                TextEditor(text: $text)
+                    .autocorrectionDisabled()
+                    .scrollDisabled(true)
+                    .focused($isFocused)
+                    .font(Typography.FontStyle.body1Medium.font)
+                    .lineSpacing(Typography.FontStyle.body1Medium.lineSpacing)
+                    .kerning(Typography.FontStyle.body1Medium.letterSpacing)
+                    .foregroundColor(status.textColor)
+                    .tint(Color.neutral800)
+                    .frame(minHeight: textHeight, maxHeight: .infinity)
+                    .padding(.vertical, TBoxTextEditor.verticalPadding)
+                    .padding(.horizontal, TBoxTextEditor.horizontalPadding)
+                    .background(Color.common0)
+                    .scrollContentBackground(.hidden)
+                    .cornerRadius(8)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(status.borderColor(isFocused: isFocused), lineWidth: 1)
+                    )
+                    .frame(height: size.height)
+
+                if text.isEmpty {
+                    Text(placeholder)
+                        .typographyStyle(.body1Medium, with: .neutral400)
+                        .padding(.vertical, TBoxTextEditor.verticalPadding + 8)
+                        .padding(.horizontal, TBoxTextEditor.horizontalPadding + 4)
+                }
+            }
+            if let footer {
+                footer
+            }
+        }
+    }
+}
+
+public extension TBoxTextEditor {
+    /// TBoxTextEditor의 Footer입니다
+    struct Footer: View {
+        /// 최대 입력 가능 글자 수
+        private let textLimit: Int
+        /// 입력된 텍스트 카운트
+        private var textCount: Int
+        /// 경고 텍스트
+        private var warningText: String
+        /// 텍스트 필드 상태
+        @Binding private var status: Status
+
+        /// Footer 생성자
+        /// - Parameters:
+        ///   - textLimit: 최대 입력 가능 글자 수.
+        ///   - status: 텍스트 에디터의 상태를 관리하는 바인딩.
+        ///   - textCount: 입력된 텍스트 글자 수.
+        public init(
+            textLimit: Int,
+            status: Binding<Status>,
+            textCount: Int,
+            warningText: String = "글자 수를 초과했어요"
+        ) {
+            self.textLimit = textLimit
+            self.textCount = textCount
+            self._status = status
+            self.warningText = warningText
+        }
+
+        public var body: some View {
+            HStack {
+                if status == .invalid {
+                    Text(warningText)
+                        .typographyStyle(.label2Medium, with: status.footerColor)
+                }
+                Spacer()
+                Text("\(textCount)/\(textLimit)")
+                    .typographyStyle(.label2Medium, with: status.footerColor)
+            }
+        }
+    }
+}
+
+public extension TBoxTextEditor {
+    /// TextEditor에 표시되는 상태입니다
+    enum Status {
+        case empty
+        case filled
+        case invalid
+
+        /// 테두리 색상 설정
+        func borderColor(isFocused: Bool) -> Color {
+            switch self {
+            case .empty:
+                return isFocused ? .neutral600 : .neutral300
+            case .filled:
+                return isFocused ? .neutral600 : .neutral300
+            case .invalid:
+                return .red500
+            }
+        }
+
+        /// 텍스트 색상 설정
+        var textColor: Color {
+            switch self {
+            case .empty:
+                return .neutral400
+            case .filled, .invalid:
+                return .neutral600
+            }
+        }
+
+        /// 푸터 색상 설정
+        var footerColor: Color {
+            switch self {
+            case .empty, .filled:
+                return .neutral300
+            case .invalid:
+                return .red500
+            }
+        }
+    }
+
+    /// TextEditor의 크기
+    enum Size {
+        case small
+        case large
+
+        /// 높이
+        var height: CGFloat {
+            switch self {
+            case .small:
+                return 52
+            case .large:
+                return 130
+            }
+        }
+    }
+}

--- a/TnT/Projects/DesignSystem/Sources/Components/TextField/TBoxTextEditor.swift
+++ b/TnT/Projects/DesignSystem/Sources/Components/TextField/TBoxTextEditor.swift
@@ -2,7 +2,7 @@
 //  TBoxTextEditor.swift
 //  DesignSystem
 //
-//  Created by Codex on 11/22/25.
+//  Created by 박민서 on 11/22/25.
 //  Copyright © 2025 yapp25thTeamTnT. All rights reserved.
 //
 

--- a/TnT/Projects/DesignSystem/Sources/Components/TextField/TBoxTextField.swift
+++ b/TnT/Projects/DesignSystem/Sources/Components/TextField/TBoxTextField.swift
@@ -2,7 +2,7 @@
 //  TBoxTextField.swift
 //  DesignSystem
 //
-//  Created by Claude on 11/21/25.
+//  Created by 박민서 on 11/21/25.
 //  Copyright © 2025 yapp25thTeamTnT. All rights reserved.
 //
 

--- a/TnT/Projects/DesignSystem/Sources/Components/TextField/TBoxTextField.swift
+++ b/TnT/Projects/DesignSystem/Sources/Components/TextField/TBoxTextField.swift
@@ -1,0 +1,302 @@
+//
+//  TBoxTextField.swift
+//  DesignSystem
+//
+//  Created by Claude on 11/21/25.
+//  Copyright © 2025 yapp25thTeamTnT. All rights reserved.
+//
+
+import SwiftUI
+
+/// TnT 앱 내에서 사용되는 박스형(테두리) 스타일의 커스텀 텍스트 필드 컴포넌트입니다.
+/// 기존 TTextField와 기능은 동일하며, 라인형 대신 박스형 디자인을 사용합니다.
+public struct TBoxTextField: View {
+
+    /// 텍스트 필드 우측에 표시될 RightView
+    private let rightView: RightView?
+    /// Placeholder 텍스트
+    private let placeholder: String
+
+    /// 입력 텍스트
+    @Binding private var text: String
+    /// 텍스트 필드 상태
+    @Binding private var status: Status
+    /// 텍스트 컬러 상태
+    @State private var textColor: Color = .neutral400
+    /// Border 컬러 상태
+    @State private var borderColor: Color = .neutral300
+    /// 외부에서 전달되는 포커스 상태 (실제 키보드 포커스와 분리 가능)
+    private let externalFocus: Bool?
+    /// 하이라이트용 포커스 상태 (외부/내부 포커스를 모두 반영)
+    @State private var highlightFocus: Bool = false
+    /// 텍스트 필드 포커스 상태
+    @FocusState var isFocused: Bool
+
+    /// - Parameters:
+    ///   - placeholder: Placeholder 텍스트 (기본값: "내용을 입력해주세요")
+    ///   - text: 입력 텍스트 (Binding)
+    ///   - textFieldStatus: 텍스트 필드 상태 (Binding)
+    ///   - isFocused: 외부 포커스 여부(옵션). Dropdown처럼 커서 없이 하이라이트만 줄 때 사용
+    ///   - rightView: 텍스트 필드 우측에 표시될 `TBoxTextField.RightView`를 정의하는 클로저.
+    public init(
+        placeholder: String = "내용을 입력해주세요",
+        text: Binding<String>,
+        textFieldStatus: Binding<Status>,
+        isFocused: Bool? = nil,
+        @ViewBuilder rightView: () -> RightView? = { nil }
+    ) {
+        self.placeholder = placeholder
+        self._text = text
+        self._status = textFieldStatus
+        self.rightView = rightView()
+        self.externalFocus = isFocused
+        let initialFocus = isFocused ?? false
+        self._highlightFocus = .init(initialValue: initialFocus)
+        self._textColor = .init(initialValue: textFieldStatus.wrappedValue.textColor(isFocused: initialFocus))
+        self._borderColor = .init(initialValue: textFieldStatus.wrappedValue.borderColor(isFocused: initialFocus))
+    }
+
+    public var body: some View {
+        HStack(spacing: 0) {
+            TextField(placeholder, text: $text)
+                .autocorrectionDisabled()
+                .focused($isFocused)
+                .font(Typography.FontStyle.body1Medium.font)
+                .lineSpacing(Typography.FontStyle.body1Medium.lineSpacing)
+                .kerning(Typography.FontStyle.body1Medium.letterSpacing)
+                .tint(Color.neutral800)
+                .foregroundStyle(textColor)
+                .padding(.leading, 12)
+                .padding(.vertical, 12)
+                .frame(height: 42)
+                .onChange(of: status) {
+                    textColor = status.textColor(isFocused: highlightFocus)
+                    borderColor = status.borderColor(isFocused: highlightFocus)
+                }
+                .onChange(of: isFocused) {
+                    if externalFocus == nil {
+                        highlightFocus = isFocused
+                        textColor = status.textColor(isFocused: highlightFocus)
+                        borderColor = status.borderColor(isFocused: highlightFocus)
+                    }
+                }
+                .onChange(of: externalFocus ?? false) { newValue in
+                    guard externalFocus != nil else { return }
+                    highlightFocus = newValue
+                    textColor = status.textColor(isFocused: newValue)
+                    borderColor = status.borderColor(isFocused: newValue)
+                }
+
+            if let rightView {
+                rightView
+                    .padding(.trailing, 8)
+            } else {
+                Spacer()
+                    .frame(width: 12)
+            }
+        }
+        .background(Color.common0)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(borderColor, lineWidth: 1)
+        )
+    }
+}
+
+public extension TBoxTextField.RightView {
+    enum Style {
+        case unit(text: String, status: TBoxTextField.Status)
+        case button(title: String, state: TButton.ButtonState, tapAction: () -> Void)
+        case dropDown(tintColor: Color, tapAction: () -> Void)
+    }
+}
+
+public extension TBoxTextField {
+    /// TextField 우측 컨텐츠 뷰입니다
+    struct RightView: View {
+        /// 컨텐츠 스타일
+        private let style: RightView.Style
+
+        public init(style: RightView.Style) {
+            self.style = style
+        }
+
+        public var body: some View {
+
+            switch style {
+            case let .unit(text, status):
+                Text(text)
+                    .typographyStyle(.body1Medium, with: status.textColor(isFocused: true))
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 3)
+
+            case let .button(title, state, tapAction):
+                TButton(
+                    title: title,
+                    config: .small,
+                    state: state,
+                    action: tapAction
+                )
+                .frame(width: 66)
+
+            case let .dropDown(tintColor, tapAction):
+                Button(action: tapAction) {
+                    Image(.icnArrowDown)
+                        .renderingMode(.template)
+                        .resizable()
+                        .tint(tintColor)
+                        .frame(width: 32, height: 32)
+                }
+            }
+        }
+    }
+
+    /// TextField 상단 헤더입니다
+    struct Header: View {
+        /// 필수 여부를 표시
+        private let isRequired: Bool
+        /// 헤더의 제목
+        private let title: String
+        /// 입력 가능한 글자 수 제한
+        private let limitCount: Int?
+        /// 입력된 텍스트 카운트
+        private var textCount: Int?
+
+        public init(
+            isRequired: Bool,
+            title: String,
+            limitCount: Int?,
+            textCount: Int?
+        ) {
+            self.isRequired = isRequired
+            self.title = title
+            self.limitCount = limitCount
+            self.textCount = textCount
+        }
+
+        public var body: some View {
+            HStack(spacing: 0) {
+                Text(title)
+                    .typographyStyle(.body1Bold, with: .neutral900)
+                if isRequired {
+                    Text("*")
+                        .typographyStyle(.body1Bold, with: .red500)
+                }
+
+                Spacer()
+
+                if let limitCount, let textCount {
+                    Text("\(textCount)/\(limitCount)자")
+                        .typographyStyle(.label1Medium, with: textCount > limitCount ? .red500 : .neutral400)
+                        .padding(.horizontal, 4)
+                        .padding(.vertical, 2)
+                }
+            }
+        }
+    }
+
+    /// TextField 하단 푸터입니다
+    struct Footer: View {
+        /// 푸터 텍스트
+        private let footerText: String
+        /// 텍스트 필드 상태
+        private var status: Status
+
+        public init(footerText: String, status: Status) {
+            self.footerText = footerText
+            self.status = status
+        }
+
+        public var body: some View {
+            Text(footerText)
+                .typographyStyle(.body2Medium, with: status.footerColor)
+        }
+    }
+}
+
+public extension TBoxTextField {
+    /// TextField에 표시되는 상태입니다
+    enum Status: Equatable {
+        case empty
+        case filled
+        case invalid
+        case valid
+
+        /// Border 색상 설정
+        func borderColor(isFocused: Bool) -> Color {
+            switch self {
+            case .empty:
+                return isFocused ? .neutral600 : .neutral300
+            case .filled:
+                return isFocused ? .neutral600 : .neutral300
+            case .invalid:
+                return .red500
+            case .valid:
+                return .blue500
+            }
+        }
+
+        /// 텍스트 색상 설정
+        func textColor(isFocused: Bool) -> Color {
+            switch self {
+            case .empty:
+                return .neutral400
+            case .filled, .invalid, .valid:
+                return .neutral600
+            }
+        }
+
+        /// 푸터 색상 설정
+        var footerColor: Color {
+            switch self {
+            case .empty, .filled:
+                return .clear
+            case .invalid:
+                return .red500
+            case .valid:
+                return .blue500
+            }
+        }
+    }
+}
+
+struct TBoxTextFieldModifier: ViewModifier {
+    /// Textfield 상단에 표시될 헤더
+    private let header: TBoxTextField.Header?
+    /// Textfield 하단에 표시될 푸터
+    private let footer: TBoxTextField.Footer?
+
+    public init(header: TBoxTextField.Header?, footer: TBoxTextField.Footer?) {
+        self.header = header
+        self.footer = footer
+    }
+
+    func body(content: Content) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // 헤더 추가
+            if let header {
+                header
+            }
+
+            // 본체(TextField)
+            content
+
+            // 푸터 추가
+            if let footer {
+                footer
+            }
+        }
+    }
+}
+
+public extension TBoxTextField {
+    /// 헤더와 푸터를 포함한 레이아웃을 텍스트 필드에 적용합니다.
+    ///
+    /// - Parameters:
+    ///   - header: `TBoxTextField.Header`로 정의된 상단 헤더. (옵션)
+    ///   - footer: `TBoxTextField.Footer`로 정의된 하단 푸터. (옵션)
+    /// - Returns: 헤더와 푸터가 포함된 새로운 View.
+    func withSectionLayout(header: TBoxTextField.Header? = nil, footer: TBoxTextField.Footer? = nil) -> some View {
+        self.modifier(TBoxTextFieldModifier(header: header, footer: footer))
+    }
+}

--- a/TnT/Projects/DesignSystem/Sources/DesignSystem/Image+DesignSystem.swift
+++ b/TnT/Projects/DesignSystem/Sources/DesignSystem/Image+DesignSystem.swift
@@ -35,6 +35,7 @@ public extension ImageResource {
     static let icnCheckMarkEmpty: ImageResource = DesignSystemAsset.icnCheckMarkEmpty.imageResource
     static let icnCheckMarkGreen: ImageResource = DesignSystemAsset.icnCheckMarkGreen.imageResource
     static let icnCheckMarkFilled: ImageResource = DesignSystemAsset.icnCheckMarkFilled.imageResource
+    static let icnCheckMarkLightGreen: ImageResource = DesignSystemAsset.icnCheckMarkLightGreen.imageResource
     static let icnCheckButtonUnselected: ImageResource = DesignSystemAsset.icnCheckButtonUnselected.imageResource
     static let icnCheckButtonSelected: ImageResource = DesignSystemAsset.icnCheckButtonSelected.imageResource
     static let icnStarEmpty: ImageResource = DesignSystemAsset.icnStarEmpty.imageResource
@@ -71,6 +72,7 @@ public extension ImageResource {
     static let icnTriangleLeft32px: ImageResource = DesignSystemAsset.icnTriangleLeft32.imageResource
     static let icnTriangleRight32px: ImageResource = DesignSystemAsset.icnTriangleRight32.imageResource
     static let icnWarning: ImageResource = DesignSystemAsset.icnWarning.imageResource
+    static let icnQuestionMark: ImageResource = DesignSystemAsset.icnQuestionMark.imageResource
 }
 
 // MARK: Image

--- a/TnT/Projects/Presentation/Sources/AddPTSession/TrainerAddPTSessionFeature.swift
+++ b/TnT/Projects/Presentation/Sources/AddPTSession/TrainerAddPTSessionFeature.swift
@@ -37,11 +37,11 @@ public struct TrainerAddPTSessionFeature {
         
         // MARK: UI related state
         /// 텍스트 필드 상태 (빈 값 / 입력됨 / 유효하지 않음)
-        var view_traineeStatus: TTextField.Status
-        var view_ptDateStatus: TTextField.Status
-        var view_startTimeStatus: TTextField.Status
-        var view_endTimeStatus: TTextField.Status
-        var view_memoStatus: TTextEditor.Status
+        var view_traineeStatus: TBoxTextField.Status
+        var view_ptDateStatus: TBoxTextField.Status
+        var view_startTimeStatus: TBoxTextField.Status
+        var view_endTimeStatus: TBoxTextField.Status
+        var view_memoStatus: TBoxTextEditor.Status
         /// 현재 포커스된 필드
         var view_focusField: FocusField?
         /// BottomSheet에 표시할 아이템
@@ -67,11 +67,11 @@ public struct TrainerAddPTSessionFeature {
             startTime: Date? = nil,
             endTime: Date? = nil,
             memo: String = "",
-            view_traineeStatus: TTextField.Status = .empty,
-            view_ptDateStatus: TTextField.Status = .empty,
-            view_startTimeStatus: TTextField.Status = .empty,
-            view_endTimeStatus: TTextField.Status = .empty,
-            view_memoStatus: TTextEditor.Status = .empty,
+            view_traineeStatus: TBoxTextField.Status = .empty,
+            view_ptDateStatus: TBoxTextField.Status = .empty,
+            view_startTimeStatus: TBoxTextField.Status = .empty,
+            view_endTimeStatus: TBoxTextField.Status = .empty,
+            view_memoStatus: TBoxTextEditor.Status = .empty,
             view_focusField: FocusField? = nil,
             view_bottomSheetItem: BottomSheetItem? = nil,
             view_isSubmitButtonEnabled: Bool = false,
@@ -237,17 +237,23 @@ public struct TrainerAddPTSessionFeature {
                     return .send(.api(.registerPTSession))
                     
                 case .tapPopUpSecondaryButton(let popUp):
-                    guard popUp != nil else { return .none }
-                    return .concatenate(
-                        setPopUpStatus(&state, status: nil),
-                        .send(.setNavigating)
-                    )
+                    guard let popUp else { return .none }
+                    switch popUp {
+                    case .cancelSessionAdd, .planExercise:
+                        return .concatenate(
+                            setPopUpStatus(&state, status: nil),
+                            .run { _ in await self.dismiss() }
+                        )
+                    }
                     
                 case .tapPopUpPrimaryButton(let popUp):
-                    guard popUp != nil else { return .none }
-                    return popUp == .sessionAdded
-                    ? .send(.setNavigating)
-                    : setPopUpStatus(&state, status: nil)
+                    guard let popUp else { return .none }
+                    switch popUp {
+                    case .cancelSessionAdd:
+                        return setPopUpStatus(&state, status: nil)
+                    case .planExercise:
+                        return setPopUpStatus(&state, status: nil)
+                    }
                     
                 case let .setFocus(oldFocus, newFocus):
                     state.view_focusField = newFocus
@@ -282,7 +288,7 @@ public struct TrainerAddPTSessionFeature {
                                 traineeId: traineeId
                             )
                         )
-                        await send(.setPopUp(.sessionAdded))
+                        await send(.setPopUp(.planExercise))
                     }
                 }
                 
@@ -303,13 +309,13 @@ public struct TrainerAddPTSessionFeature {
 // MARK: Internal Logic
 private extension TrainerAddPTSessionFeature {
     /// 메모 필드 상태 검증
-    func validateMemo(_ memo: String) -> TTextEditor.Status {
+    func validateMemo(_ memo: String) -> TBoxTextEditor.Status {
         guard !memo.isEmpty else { return .empty }
         return memo.count > 30 ? .invalid : .filled
     }
     
     /// 시작 시간 종료 시간 필드 상태 검증
-    func validateTimes(startTime: Date?, endTime: Date?) -> TTextField.Status? {
+    func validateTimes(startTime: Date?, endTime: Date?) -> TBoxTextField.Status? {
         guard let startTime, let endTime else { return nil }
         return startTime < endTime ? .filled : .invalid
     }
@@ -427,26 +433,26 @@ public extension TrainerAddPTSessionFeature {
 public extension TrainerAddPTSessionFeature {
     /// 본 화면에 팝업으로 표시되는 목록
     enum PopUp: Equatable, Sendable {
-        /// 수업 일정이 추가됐어요
-        case sessionAdded
         /// 수업 등록을 취소할까요?
         case cancelSessionAdd
+        /// 이어서 운동도 계획할까요?
+        case planExercise
         
         var title: String {
             switch self {
-            case .sessionAdded:
-                return "수업 일정이 추가됐어요"
             case .cancelSessionAdd:
                 return "수업 등록을 취소할까요?"
+            case .planExercise:
+                return "이어서 운동도 계획할까요?"
             }
         }
         
         var message: String {
             switch self {
-            case .sessionAdded:
-                return "등록된 일정은 트레이니에게도 표시돼요!"
             case .cancelSessionAdd:
                 return "일정이 저장되지 않아요"
+            case .planExercise:
+                return "수업 전 진행할 운동을 계획할 수 있어요"
             }
         }
         
@@ -454,7 +460,7 @@ public extension TrainerAddPTSessionFeature {
             switch self {
             case .cancelSessionAdd:
                 return true
-            case .sessionAdded:
+            case .planExercise:
                 return false
             }
         }
@@ -463,17 +469,17 @@ public extension TrainerAddPTSessionFeature {
             switch self {
             case .cancelSessionAdd:
                 return .tapPopUpSecondaryButton(popUp: self)
-            case .sessionAdded:
-                return nil
+            case .planExercise:
+                return .tapPopUpSecondaryButton(popUp: self)
             }
         }
         
         var primaryTitle: String {
             switch self {
-            case .sessionAdded:
-                return "확인"
             case .cancelSessionAdd:
                 return "계속 수정"
+            case .planExercise:
+                return "네"
             }
         }
         

--- a/TnT/Projects/Presentation/Sources/AddPTSession/TrainerAddPTSessionFeature.swift
+++ b/TnT/Projects/Presentation/Sources/AddPTSession/TrainerAddPTSessionFeature.swift
@@ -438,6 +438,15 @@ public extension TrainerAddPTSessionFeature {
         /// 이어서 운동도 계획할까요?
         case planExercise
         
+        var icon: TPopupAlertState.PopupIcon? {
+            switch self {
+            case .cancelSessionAdd:
+                return nil
+            case .planExercise:
+                return .checkMarkLightGreen
+            }
+        }
+        
         var title: String {
             switch self {
             case .cancelSessionAdd:

--- a/TnT/Projects/Presentation/Sources/AddPTSession/TrainerAddPTSessionFeature.swift
+++ b/TnT/Projects/Presentation/Sources/AddPTSession/TrainerAddPTSessionFeature.swift
@@ -171,7 +171,7 @@ public struct TrainerAddPTSessionFeature {
                     return .none
                     
                 case .tapNavBackButton:
-                    if state.view_isSubmitButtonEnabled {
+                    if hasFormChanges(state) {
                         return self.setPopUpStatus(&state, status: .cancelSessionAdd)
                     } else {
                         return .run { send in
@@ -386,6 +386,19 @@ private extension TrainerAddPTSessionFeature {
             minute: timeComponents.minute,
             second: timeComponents.second
         ))
+    }
+    
+    /// 사용자가 폼에 값을 입력했는지 확인합니다
+    func hasFormChanges(_ state: State) -> Bool {
+        if state.trainee != nil || state.startTime != nil || state.endTime != nil || !state.memo.isEmpty {
+            return true
+        }
+        
+        if let ptDate = state.ptDate, !Calendar.current.isDate(ptDate, inSameDayAs: state.calendarSelectedDate) {
+            return true
+        }
+        
+        return false
     }
 }
 

--- a/TnT/Projects/Presentation/Sources/AddPTSession/TrainerAddPTSessionView.swift
+++ b/TnT/Projects/Presentation/Sources/AddPTSession/TrainerAddPTSessionView.swift
@@ -348,7 +348,7 @@ public struct TrainerAddPTSessionView: View {
                 alertState: .init(
                     title: popUp.title,
                     message: popUp.message,
-                    showAlertIcon: popUp.showAlertIcon,
+                    showAlertIcon: popUp.showAlertIcon, icon: popUp.icon,
                     buttons: buttons
                 )
             )

--- a/TnT/Projects/Presentation/Sources/AddPTSession/TrainerAddPTSessionView.swift
+++ b/TnT/Projects/Presentation/Sources/AddPTSession/TrainerAddPTSessionView.swift
@@ -39,10 +39,7 @@ public struct TrainerAddPTSessionView: View {
             
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
-                    Header()
-                        .padding(.bottom, 28)
-                    
-                    VStack(spacing: 48) {
+                    VStack(spacing: 32) {
                         TraineeDropDown()
                         
                         PtDateDropDown()
@@ -56,7 +53,7 @@ public struct TrainerAddPTSessionView: View {
                         
                         Memo()
                     }
-                    .padding(.horizontal, 20)
+                    .padding(20)
                     
                     Spacer()
                 }
@@ -65,12 +62,14 @@ public struct TrainerAddPTSessionView: View {
         }
         .bottomFixWith {
             TBottomButton(
-                title: "완료",
+                title: "다음",
                 isEnable: store.view_isSubmitButtonEnabled
             ) {
                 send(.tapSubmitButton)
             }
+            .clipShape(.rect(cornerRadius: 12))
             .padding(.bottom, .safeAreaBottom)
+            .padding(.horizontal, 16)
             .disabled(!store.view_isSubmitButtonEnabled)
             .debounce()
         }
@@ -112,8 +111,16 @@ public struct TrainerAddPTSessionView: View {
             PopUpView()
         }
         .onChange(of: store.view_bottomSheetItem) { oldValue, newValue in
-            if oldValue != newValue {
-                send(.setFocus(oldValue?.field, newValue?.field))
+            guard oldValue?.field != newValue?.field else { return }
+            if let newField = newValue?.field {
+                send(.setFocus(store.view_focusField, newField))
+            } else {
+                send(.setFocus(oldValue?.field, nil))
+            }
+        }
+        .onChange(of: store.view_focusField) { _, newValue in
+            if focusedField != newValue {
+                focusedField = newValue
             }
         }
         .onChange(of: focusedField) { oldValue, newValue in
@@ -138,22 +145,22 @@ public struct TrainerAddPTSessionView: View {
     
     @ViewBuilder
     private func TraineeDropDown() -> some View {
-        TTextField(
+        TBoxTextField(
             placeholder: "회원을 입력해주세요",
             text: Binding(get: {
                 store.trainee?.name ?? ""
             }, set: { _ in }),
-            textFieldStatus: $store.view_traineeStatus
+            textFieldStatus: $store.view_traineeStatus,
+            isFocused: store.view_focusField == .trainee
         ) {
-            TTextField.RightView(
+            TBoxTextField.RightView(
                 style: .dropDown(
-                    tintColor: focusedField == .ptDate ? Color.neutral600 : Color.neutral400,
+                    tintColor: store.view_focusField == .trainee ? Color.neutral600 : Color.neutral400,
                     tapAction: { }
                 )
             )
         }
         .withSectionLayout(header: .init(isRequired: true, title: "회원선택", limitCount: nil, textCount: nil))
-        .focused($focusedField, equals: .ptDate)
         .allowsHitTesting(false)
         .overlay(
             Rectangle()
@@ -167,22 +174,22 @@ public struct TrainerAddPTSessionView: View {
     
     @ViewBuilder
     private func PtDateDropDown() -> some View {
-        TTextField(
+        TBoxTextField(
             placeholder: "날짜를 입력해주세요",
             text: Binding(get: {
                 store.ptDate?.toString(format: .yyyyMMddSlash) ?? ""
             }, set: { _ in }),
-            textFieldStatus: $store.view_ptDateStatus
+            textFieldStatus: $store.view_ptDateStatus,
+            isFocused: store.view_focusField == .ptDate
         ) {
-            TTextField.RightView(
+            TBoxTextField.RightView(
                 style: .dropDown(
-                    tintColor: focusedField == .ptDate ? Color.neutral600 : Color.neutral400,
+                    tintColor: store.view_focusField == .ptDate ? Color.neutral600 : Color.neutral400,
                     tapAction: { }
                 )
             )
         }
         .withSectionLayout(header: .init(isRequired: true, title: "PT 날짜", limitCount: nil, textCount: nil))
-        .focused($focusedField, equals: .trainee)
         .allowsHitTesting(false)
         .overlay(
             Rectangle()
@@ -198,22 +205,22 @@ public struct TrainerAddPTSessionView: View {
     private func TimeDropDown() -> some View {
         HStack(alignment: .bottom, spacing: 12) {
             // StartTime
-            TTextField(
+            TBoxTextField(
                 placeholder: Date().toString(format: .HHmm),
                 text: Binding(get: {
                     store.startTime?.toString(format: .HHmm) ?? ""
                 }, set: { _ in }),
-                textFieldStatus: $store.view_startTimeStatus
+                textFieldStatus: $store.view_startTimeStatus,
+                isFocused: store.view_focusField == .startTime
             ) {
-                TTextField.RightView(
+                TBoxTextField.RightView(
                     style: .dropDown(
-                        tintColor: focusedField == .ptDate ? Color.neutral600 : Color.neutral400,
+                        tintColor: store.view_focusField == .startTime ? Color.neutral600 : Color.neutral400,
                         tapAction: { }
                     )
                 )
             }
             .withSectionLayout(header: .init(isRequired: true, title: "시작 시간", limitCount: nil, textCount: nil))
-            .focused($focusedField, equals: .trainee)
             .allowsHitTesting(false)
             .overlay(
                 Rectangle()
@@ -229,22 +236,22 @@ public struct TrainerAddPTSessionView: View {
                 .padding(8)
             
             // EndTime
-            TTextField(
+            TBoxTextField(
                 placeholder: Date().addingTimeInterval(3600).toString(format: .HHmm),
                 text: Binding(get: {
                     store.endTime?.toString(format: .HHmm) ?? ""
                 }, set: { _ in }),
-                textFieldStatus: $store.view_endTimeStatus
+                textFieldStatus: $store.view_endTimeStatus,
+                isFocused: store.view_focusField == .endTime
             ) {
-                TTextField.RightView(
+                TBoxTextField.RightView(
                     style: .dropDown(
-                        tintColor: focusedField == .ptDate ? Color.neutral600 : Color.neutral400,
+                        tintColor: store.view_focusField == .endTime ? Color.neutral600 : Color.neutral400,
                         tapAction: { }
                     )
                 )
             }
             .withSectionLayout(header: .init(isRequired: true, title: "종료 시간", limitCount: nil, textCount: nil))
-            .focused($focusedField, equals: .endTime)
             .allowsHitTesting(false)
             .overlay(
                 Rectangle()
@@ -310,7 +317,7 @@ public struct TrainerAddPTSessionView: View {
     private func Memo() -> some View {
         VStack(spacing: 8) {
             TTextField.Header(isRequired: false, title: "메모하기", limitCount: nil, textCount: nil)
-            TTextEditor(
+            TBoxTextEditor(
                 placeholder: "PT 수업에서 기억해야 할 것을 메모해보세요",
                 text: $store.memo,
                 textEditorStatus: $store.view_memoStatus,

--- a/TnT/Projects/Presentation/Sources/Home/Trainer/TrainerHomeView.swift
+++ b/TnT/Projects/Presentation/Sources/Home/Trainer/TrainerHomeView.swift
@@ -31,12 +31,6 @@ public struct TrainerHomeView: View {
             }
             .background(Color.neutral100)
         }
-        .background(
-            VStack {
-                Color.common0
-                Color.neutral100
-            }
-        )
         .overlay(alignment: .bottomTrailing) {
             SessionAddButton()
         }
@@ -73,7 +67,8 @@ public struct TrainerHomeView: View {
                 TCalendarView(
                     selectedDate: $store.selectedDate,
                     currentPage: $store.view_currentPage,
-                    events: store.events
+                    events: store.events,
+                    mode: .week
                 )
                 .onChange(of: store.state.view_currentPage, { oldValue, newValue in
                     let current: Int = Calendar.current.component(.month, from: oldValue)


### PR DESCRIPTION
## 📌 What is the PR?
트레이너 홈 및 수업 추가 화면에 박스형(테두리) 스타일의 텍스트 필드 컴포넌트를 적용하고, 
트레이너 홈 캘린더를 월간 모드에서 주간 모드로 변경했습니다.

## 🪄 Changes
- TBoxTextField 컴포넌트 구현 
- TBoxTextEditor 컴포넌트 구현 
- TrainerHomeView 주간 캘린더 적용 (mode: .week)
- TrainerAddPTSessionView 모든 필드를 박스형으로 교체 (4개 필드 + 메모)
- externalFocus 기능 추가 (드롭다운 필드 하이라이트 지원)
- 포커스 동기화 로직 개선

## 🌐 Common Changes
### 1. TBoxTextField 컴포넌트, TBoxTextEditor 컴포넌트 작성

### 2. TrainerHomeView 주간 캘린더
- **변경**: TCalendarView에 `mode: .week` 추가
- **레이아웃**: 캘린더 섹션 배경색을 common0로 고정, safe area 포함 오버레이로 높이 보정
- **기능 유지**: events, selectedDate, currentPage, onChange 로직 그대로 유지

## 🔥 PR Point

### 1. externalFocus 기능으로 드롭다운 하이라이트 지원
```swift
public init(
    placeholder: String = "내용을 입력해주세요",
    text: Binding<String>,
    textFieldStatus: Binding<Status>,
    isFocused: Bool? = nil,  // externalFocus
    @ViewBuilder rightView: () -> RightView? = { nil }
)
```
- `allowsHitTesting(false)` 구조에서 실제 TextField는 포커스를 받지 않습니다.
- 하지만 사용자에게는 포커스된 것처럼 보여야 하므로
- `externalFocus` 파라미터로 Feature state와 UI 하이라이트를 동기화했습니다.
- TrainerAddPTSessionView의 `view_focusField`와 연동하여 드롭다운 탭 시 하이라이트 표시했습니다..

## 🙆🏻 To Reviewers
- 다음 작업 내용은 더 다듬어서 올리도록 하겠읍니다...

## 💭 Related Issues
- Resolved: #310
